### PR TITLE
Misc playground fixes

### DIFF
--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -6,7 +6,8 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "start": "blockly-scripts start"
   },
   "main": "dist/index.js",
   "module": "./src/index.js",

--- a/plugins/dev-tools/src/addGUIControls.js
+++ b/plugins/dev-tools/src/addGUIControls.js
@@ -155,7 +155,7 @@ export function addGUIControls(createWorkspace, defaultOptions, config = {}) {
     guiState.themeName = defaultThemeName;
 
     // Close all folders.
-    gui.__folders.forEach((f) => f.close());
+    Object.values(gui.__folders).forEach((f) => f.close());
 
     onChangeInternal();
   };

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -342,7 +342,7 @@ export function createPlayground(container, createWorkspace,
     registerTabButtons(editor, playground, tabButtons, updateEditor);
 
     // Register editor commands.
-    registerEditorCommands(editor, playground, xmlModel);
+    registerEditorCommands(editor, playground);
 
     return playground;
   });
@@ -375,9 +375,8 @@ function registerTabButtons(editor, playground, tabButtons, updateEditor) {
  * Register editor commands / shortcuts.
  * @param {monaco.editor.IStandaloneCodeEditor} editor The monaco editor.
  * @param {PlaygroundAPI} playground The current playground.
- * @param {monaco.editor.IModel} xmlModel The XML model.
  */
-function registerEditorCommands(editor, playground, xmlModel) {
+function registerEditorCommands(editor, playground) {
   const load = () => {
     if (playground.getCurrentTab().state.name !== 'XML') {
       return;

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -276,7 +276,7 @@ export function createPlayground(container, createWorkspace,
       });
       return workspace;
     }, defaultOptions, {
-      disableResize: false,
+      disableResize: true,
       toolboxes: config.toolboxes,
     });
 

--- a/plugins/dev-tools/src/playground/ui.js
+++ b/plugins/dev-tools/src/playground/ui.js
@@ -68,14 +68,14 @@ export function renderPlayground(container) {
   guiContainer.style.maxHeight = '50%';
   guiContainer.style.flex = '1';
   guiContainer.style.background = '#000';
-  guiContainer.style.overflow = 'scroll';
+  guiContainer.style.overflow = 'auto';
   playgroundDiv.appendChild(guiContainer);
 
   // Code area.
 
   const codeWrapper = document.createElement('div');
+  codeWrapper.style.maxHeight = '50%';
   codeWrapper.style.background = '#1E1E1E';
-  codeWrapper.style.height = '100%';
   codeWrapper.style.flex = '1';
   playgroundDiv.appendChild(codeWrapper);
 
@@ -88,7 +88,7 @@ export function renderPlayground(container) {
   codeWrapper.appendChild(tabContainer);
 
   const tabsDiv = document.createElement('div');
-  tabsDiv.style.overflow = 'scroll hidden';
+  tabsDiv.style.overflow = 'auto hidden';
   tabsDiv.style.width = 'calc(100% - 50px)';
   tabContainer.appendChild(tabsDiv);
 

--- a/plugins/dev-tools/src/populateRandom.js
+++ b/plugins/dev-tools/src/populateRandom.js
@@ -18,7 +18,8 @@ import Blockly from 'blockly/core';
 export function populateRandom(workspace, count) {
   const names = [];
   for (const blockName in Blockly.Blocks) {
-    if (Object.prototype.hasOwnProperty.call(Blockly.Blocks, blockName)) {
+    if (Object.prototype.hasOwnProperty.call(Blockly.Blocks, blockName) &&
+      Object.prototype.hasOwnProperty.call(Blockly.Blocks[blockName], 'init')) {
       names.push(blockName);
     }
   }

--- a/plugins/dev-tools/test/index.html
+++ b/plugins/dev-tools/test/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Blockly Dev-Tools Playground</title>
+  <style>
+    html, body {
+      margin: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script src="../build/test_bundle.js"></script>
+</body>
+
+</html>

--- a/plugins/dev-tools/test/index.js
+++ b/plugins/dev-tools/test/index.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Dev-tools Playground test.
+ * @author samelh@google.com (Sam El-Huseini)
+ */
+
+import * as Blockly from 'blockly';
+import {createPlayground, toolboxCategories} from '../src/index';
+
+/**
+ * Create a workspace.
+ * @param {HTMLElement} blocklyDiv The blockly container div.
+ * @param {!Blockly.BlocklyOptions} options The Blockly options.
+ * @return {!Blockly.WorkspaceSvg} The created workspace.
+ */
+function createWorkspace(blocklyDiv, options) {
+  const workspace = Blockly.inject(blocklyDiv, options);
+  return workspace;
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  const defaultOptions = {
+    toolbox: toolboxCategories,
+  };
+  createPlayground(document.getElementById('root'), createWorkspace,
+      defaultOptions);
+});

--- a/plugins/jsconfig.json
+++ b/plugins/jsconfig.json
@@ -5,5 +5,5 @@
     "checkJs": true,
     "resolveJsonModule": true,
   },
-  "exclude": ["node_modules", "field-date"]
+  "exclude": ["node_modules", "build", "dist", "field-date"]
 }


### PR DESCRIPTION
Misc playground fixes, see commit history. 

Summary: 
- Save GUI folder open state locally.
- Handle load / save events on the document level
- Only populate random blocks with real blocks (ie: ones with init), and skip over namespaces.
- Exclude build and dist folders from jsconfig
- Add a test playground for dev-tools.