### PR TITLE
fix: update the eslint version in root and remove unnecessary suppress annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "devDependencies": {
-                "@blockly/eslint-config": "^2.1.5",
+                "@blockly/eslint-config": "^2.1.7",
                 "eslint": "^7.15.0",
                 "gh-pages": "^3.1.0",
                 "gulp": "^4.0.2",
@@ -214,16 +214,16 @@
             "dev": true
         },
         "node_modules/@blockly/eslint-config": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.5.tgz",
-            "integrity": "sha512-7pIH6HuRoTdVM5RQe4BaU/oo6+GDsuHEdJRu1dtTlXlcmsGWqIMpJeA453OkxLC+IxZcwCYCtlS9GhhiL/akVw==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.7.tgz",
+            "integrity": "sha512-3lIBUQAkTUcwIGbmbAJQRm89o8U6V/whwDsktfZqRU+pUrTBWRLEltBZN+go1gCOKK7e+HX6Zwu/tYduJYoxxw==",
             "dev": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.0.0",
                 "@typescript-eslint/parser": "^5.0.0",
                 "babel-eslint": "^10.1.0",
                 "eslint-config-google": "^0.14.0",
-                "eslint-plugin-jsdoc": "^36.1.1"
+                "eslint-plugin-jsdoc": "^37.2.3"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -233,26 +233,17 @@
             }
         },
         "node_modules/@es-joy/jsdoccomment": {
-            "version": "0.10.8",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.8.tgz",
-            "integrity": "sha512-3P1JiGL4xaR9PoTKUHa2N/LKwa2/eUdRqGwijMWWgBqbFEqJUVpmaOi2TcjcemrsRMgFLBzQCK4ToPhrSVDiFQ==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
+            "integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
             "dev": true,
             "dependencies": {
-                "comment-parser": "1.2.4",
+                "comment-parser": "1.3.0",
                 "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "1.1.1"
+                "jsdoc-type-pratt-parser": "~2.2.2"
             },
             "engines": {
-                "node": "^12 || ^14 || ^16"
-            }
-        },
-        "node_modules/@es-joy/jsdoccomment/node_modules/jsdoc-type-pratt-parser": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
-            "integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.0.0"
+                "node": "^12 || ^14 || ^16 || ^17"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -3942,9 +3933,9 @@
             "dev": true
         },
         "node_modules/comment-parser": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
-            "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+            "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
             "dev": true,
             "engines": {
                 "node": ">= 12.0.0"
@@ -5384,26 +5375,25 @@
             }
         },
         "node_modules/eslint-plugin-jsdoc": {
-            "version": "36.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.1.tgz",
-            "integrity": "sha512-nuLDvH1EJaKx0PCa9oeQIxH6pACIhZd1gkalTUxZbaxxwokjs7TplqY0Q8Ew3CoZaf5aowm0g/Z3JGHCatt+gQ==",
+            "version": "37.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.0.tgz",
+            "integrity": "sha512-vzy3/ltXoGtabRnjLogaEmhGxxIv5B8HK5MJLIrdxFJUvhBppZjuVuLr71DjIBi0jg6bFomwkYKjojt29cN8PA==",
             "dev": true,
             "dependencies": {
-                "@es-joy/jsdoccomment": "0.10.8",
-                "comment-parser": "1.2.4",
-                "debug": "^4.3.2",
+                "@es-joy/jsdoccomment": "~0.18.0",
+                "comment-parser": "1.3.0",
+                "debug": "^4.3.3",
+                "escape-string-regexp": "^4.0.0",
                 "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "^1.1.1",
-                "lodash": "^4.17.21",
                 "regextras": "^0.8.0",
                 "semver": "^7.3.5",
                 "spdx-expression-parse": "^3.0.1"
             },
             "engines": {
-                "node": "^12 || ^14 || ^16"
+                "node": "^12 || ^14 || ^16 || ^17"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0"
+                "eslint": "^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
@@ -5421,6 +5411,18 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint-plugin-jsdoc/node_modules/lru-cache": {
@@ -8498,9 +8500,9 @@
             "dev": true
         },
         "node_modules/jsdoc-type-pratt-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.2.0.tgz",
-            "integrity": "sha512-4STjeF14jp4bqha44nKMY1OUI6d2/g6uclHWUCZ7B4DoLzaB5bmpTkQrpqU+vSVzMD0LsKAOskcnI3I3VfIpmg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
+            "integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==",
             "dev": true,
             "engines": {
                 "node": ">=12.0.0"
@@ -13313,35 +13315,27 @@
             }
         },
         "@blockly/eslint-config": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.5.tgz",
-            "integrity": "sha512-7pIH6HuRoTdVM5RQe4BaU/oo6+GDsuHEdJRu1dtTlXlcmsGWqIMpJeA453OkxLC+IxZcwCYCtlS9GhhiL/akVw==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.7.tgz",
+            "integrity": "sha512-3lIBUQAkTUcwIGbmbAJQRm89o8U6V/whwDsktfZqRU+pUrTBWRLEltBZN+go1gCOKK7e+HX6Zwu/tYduJYoxxw==",
             "dev": true,
             "requires": {
                 "@typescript-eslint/eslint-plugin": "^5.0.0",
                 "@typescript-eslint/parser": "^5.0.0",
                 "babel-eslint": "^10.1.0",
                 "eslint-config-google": "^0.14.0",
-                "eslint-plugin-jsdoc": "^36.1.1"
+                "eslint-plugin-jsdoc": "^37.2.3"
             }
         },
         "@es-joy/jsdoccomment": {
-            "version": "0.10.8",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.8.tgz",
-            "integrity": "sha512-3P1JiGL4xaR9PoTKUHa2N/LKwa2/eUdRqGwijMWWgBqbFEqJUVpmaOi2TcjcemrsRMgFLBzQCK4ToPhrSVDiFQ==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
+            "integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
             "dev": true,
             "requires": {
-                "comment-parser": "1.2.4",
+                "comment-parser": "1.3.0",
                 "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "1.1.1"
-            },
-            "dependencies": {
-                "jsdoc-type-pratt-parser": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
-                    "integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==",
-                    "dev": true
-                }
+                "jsdoc-type-pratt-parser": "~2.2.2"
             }
         },
         "@eslint/eslintrc": {
@@ -16347,9 +16341,9 @@
             "dev": true
         },
         "comment-parser": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
-            "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+            "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
             "dev": true
         },
         "commondir": {
@@ -17735,17 +17729,16 @@
             "dev": true
         },
         "eslint-plugin-jsdoc": {
-            "version": "36.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.1.tgz",
-            "integrity": "sha512-nuLDvH1EJaKx0PCa9oeQIxH6pACIhZd1gkalTUxZbaxxwokjs7TplqY0Q8Ew3CoZaf5aowm0g/Z3JGHCatt+gQ==",
+            "version": "37.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.0.tgz",
+            "integrity": "sha512-vzy3/ltXoGtabRnjLogaEmhGxxIv5B8HK5MJLIrdxFJUvhBppZjuVuLr71DjIBi0jg6bFomwkYKjojt29cN8PA==",
             "dev": true,
             "requires": {
-                "@es-joy/jsdoccomment": "0.10.8",
-                "comment-parser": "1.2.4",
-                "debug": "^4.3.2",
+                "@es-joy/jsdoccomment": "~0.18.0",
+                "comment-parser": "1.3.0",
+                "debug": "^4.3.3",
+                "escape-string-regexp": "^4.0.0",
                 "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "^1.1.1",
-                "lodash": "^4.17.21",
                 "regextras": "^0.8.0",
                 "semver": "^7.3.5",
                 "spdx-expression-parse": "^3.0.1"
@@ -17759,6 +17752,12 @@
                     "requires": {
                         "ms": "2.1.2"
                     }
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
                 },
                 "lru-cache": {
                     "version": "6.0.0",
@@ -20026,9 +20025,9 @@
             "dev": true
         },
         "jsdoc-type-pratt-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.2.0.tgz",
-            "integrity": "sha512-4STjeF14jp4bqha44nKMY1OUI6d2/g6uclHWUCZ7B4DoLzaB5bmpTkQrpqU+vSVzMD0LsKAOskcnI3I3VfIpmg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
+            "integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==",
             "dev": true
         },
         "jsesc": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "test:ghpages": "gulp testGhPages"
     },
     "devDependencies": {
-        "@blockly/eslint-config": "^2.1.5",
+        "@blockly/eslint-config": "^2.1.7",
         "eslint": "^7.15.0",
         "gh-pages": "^3.1.0",
         "gulp": "^4.0.2",

--- a/plugins/block-dynamic-connection/package-lock.json
+++ b/plugins/block-dynamic-connection/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-dynamic-connection",
-			"version": "0.1.18",
+			"version": "0.1.19",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",
@@ -287,15 +287,16 @@
 			"dev": true
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -1478,6 +1479,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.0"
 			}
 		},
 		"node_modules/mime-db": {
@@ -2745,15 +2755,16 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -3641,6 +3652,15 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2"
+			}
+		},
+		"loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
 			}
 		},
 		"mime-db": {

--- a/plugins/block-extension-tooltip/package-lock.json
+++ b/plugins/block-extension-tooltip/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-extension-tooltip",
-			"version": "1.0.21",
+			"version": "1.0.22",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "5.20210325.1",

--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-plus-minus",
-			"version": "3.0.4",
+			"version": "3.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",
@@ -323,15 +323,16 @@
 			"dev": true
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -1532,6 +1533,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.0"
 			}
 		},
 		"node_modules/mime-db": {
@@ -2904,15 +2914,16 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -3818,6 +3829,15 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2"
+			}
+		},
+		"loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
 			}
 		},
 		"mime-db": {

--- a/plugins/block-test/package-lock.json
+++ b/plugins/block-test/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-test",
-			"version": "2.0.2",
+			"version": "2.0.3",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/content-highlight/package-lock.json
+++ b/plugins/content-highlight/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/workspace-content-highlight",
-			"version": "1.0.13",
+			"version": "1.0.14",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/continuous-toolbox/package-lock.json
+++ b/plugins/continuous-toolbox/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/continuous-toolbox",
-			"version": "2.0.22",
+			"version": "2.0.23",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/dev-create/package-lock.json
+++ b/plugins/dev-create/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/create-package",
-			"version": "1.1.6",
+			"version": "1.1.7",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"chalk": "^4.0.0",

--- a/plugins/dev-scripts/package-lock.json
+++ b/plugins/dev-scripts/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/dev-scripts",
-			"version": "1.2.12",
+			"version": "1.2.13",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/code-frame": "^7.8.3",
@@ -60,16 +60,16 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.10.tgz",
-			"integrity": "sha512-pbiIdZbCiMx/MM6toR+OfXarYix3uz0oVsnNtfdAGTcCTu3w/JGF8JhirevXLBJUu0WguSZI12qpKnx7EeMyLA==",
+			"version": "7.16.12",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
+			"integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.16.8",
 				"@babel/helper-compilation-targets": "^7.16.7",
 				"@babel/helper-module-transforms": "^7.16.7",
 				"@babel/helpers": "^7.16.7",
-				"@babel/parser": "^7.16.10",
+				"@babel/parser": "^7.16.12",
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.16.10",
 				"@babel/types": "^7.16.8",
@@ -492,9 +492,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
-			"integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
+			"version": "7.16.12",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+			"integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1732,9 +1732,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.0.tgz",
-			"integrity": "sha512-JUYa/5JwoqikCy7O7jKtuNe9Z4ZZt615G+1EKfaDGSNEpzaA2OwbV/G1v08Oa7fd1XzlFoSCvt9ePl9/6FyAug==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+			"integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -1794,9 +1794,9 @@
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
-			"integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
+			"version": "17.0.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
+			"integrity": "sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw=="
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.7",
@@ -1978,18 +1978,18 @@
 			}
 		},
 		"node_modules/@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
 			"peerDependencies": {
 				"webpack": "4.x.x || 5.x.x",
 				"webpack-cli": "4.x.x"
 			}
 		},
 		"node_modules/@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+			"integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
 			"dependencies": {
 				"envinfo": "^7.7.3"
 			},
@@ -1998,9 +1998,9 @@
 			}
 		},
 		"node_modules/@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
 			"peerDependencies": {
 				"webpack-cli": "4.x.x"
 			},
@@ -2590,9 +2590,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001300",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-			"integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+			"version": "1.0.30001303",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
+			"integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/browserslist"
@@ -3256,9 +3256,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.49",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.49.tgz",
-			"integrity": "sha512-k/0t1TRfonHIp8TJKfjBu2cKj8MqYTiEpOhci+q7CVEE5xnCQnx1pTa+V8b/sdhe4S3PR4p4iceEQWhGrKQORQ=="
+			"version": "1.4.57",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.57.tgz",
+			"integrity": "sha512-FNC+P5K1n6pF+M0zIK+gFCoXcJhhzDViL3DRIGy2Fv5PohuSES1JHR7T+GlwxSxlzx4yYbsuzCZvHxcBSRCIOw=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -4197,9 +4197,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.14.7",
@@ -4718,11 +4718,11 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
-			"integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.2.tgz",
+			"integrity": "sha512-XtmDN5w+vdFTBZaYhdJAbMqn0DP/EhkUaAeo963mojwpKMMbw6nivtFKw07D7DDOH745L5k0VL0P8KRYNEVF/g==",
 			"dependencies": {
-				"@types/http-proxy": "^1.17.5",
+				"@types/http-proxy": "^1.17.8",
 				"http-proxy": "^1.18.1",
 				"is-glob": "^4.0.1",
 				"is-plain-obj": "^3.0.0",
@@ -4730,6 +4730,9 @@
 			},
 			"engines": {
 				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"@types/express": "^4.17.13"
 			}
 		},
 		"node_modules/http-proxy-middleware/node_modules/braces": {
@@ -6796,11 +6799,11 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"node_modules/resolve": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-			"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dependencies": {
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -8227,9 +8230,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.66.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.66.0.tgz",
-			"integrity": "sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==",
+			"version": "5.67.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
+			"integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -8254,7 +8257,7 @@
 				"tapable": "^2.1.1",
 				"terser-webpack-plugin": "^5.1.3",
 				"watchpack": "^2.3.1",
-				"webpack-sources": "^3.2.2"
+				"webpack-sources": "^3.2.3"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -8273,14 +8276,14 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+			"integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.1.0",
-				"@webpack-cli/info": "^1.4.0",
-				"@webpack-cli/serve": "^1.6.0",
+				"@webpack-cli/configtest": "^1.1.1",
+				"@webpack-cli/info": "^1.4.1",
+				"@webpack-cli/serve": "^1.6.1",
 				"colorette": "^2.0.14",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",
@@ -9009,16 +9012,16 @@
 			"integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q=="
 		},
 		"@babel/core": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.10.tgz",
-			"integrity": "sha512-pbiIdZbCiMx/MM6toR+OfXarYix3uz0oVsnNtfdAGTcCTu3w/JGF8JhirevXLBJUu0WguSZI12qpKnx7EeMyLA==",
+			"version": "7.16.12",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
+			"integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.16.8",
 				"@babel/helper-compilation-targets": "^7.16.7",
 				"@babel/helper-module-transforms": "^7.16.7",
 				"@babel/helpers": "^7.16.7",
-				"@babel/parser": "^7.16.10",
+				"@babel/parser": "^7.16.12",
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.16.10",
 				"@babel/types": "^7.16.8",
@@ -9331,9 +9334,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
-			"integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ=="
+			"version": "7.16.12",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+			"integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.16.7",
@@ -10159,9 +10162,9 @@
 			}
 		},
 		"@types/eslint": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.0.tgz",
-			"integrity": "sha512-JUYa/5JwoqikCy7O7jKtuNe9Z4ZZt615G+1EKfaDGSNEpzaA2OwbV/G1v08Oa7fd1XzlFoSCvt9ePl9/6FyAug==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+			"integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -10221,9 +10224,9 @@
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
 		},
 		"@types/node": {
-			"version": "17.0.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
-			"integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
+			"version": "17.0.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
+			"integrity": "sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw=="
 		},
 		"@types/qs": {
 			"version": "6.9.7",
@@ -10405,23 +10408,23 @@
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
 			"requires": {}
 		},
 		"@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+			"integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
 			"requires": {
 				"envinfo": "^7.7.3"
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
 			"requires": {}
 		},
 		"@xtuc/ieee754": {
@@ -10861,9 +10864,9 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001300",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-			"integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA=="
+			"version": "1.0.30001303",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
+			"integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ=="
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -11370,9 +11373,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.4.49",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.49.tgz",
-			"integrity": "sha512-k/0t1TRfonHIp8TJKfjBu2cKj8MqYTiEpOhci+q7CVEE5xnCQnx1pTa+V8b/sdhe4S3PR4p4iceEQWhGrKQORQ=="
+			"version": "1.4.57",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.57.tgz",
+			"integrity": "sha512-FNC+P5K1n6pF+M0zIK+gFCoXcJhhzDViL3DRIGy2Fv5PohuSES1JHR7T+GlwxSxlzx4yYbsuzCZvHxcBSRCIOw=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -12096,9 +12099,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
 		},
 		"follow-redirects": {
 			"version": "1.14.7",
@@ -12482,11 +12485,11 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
-			"integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.2.tgz",
+			"integrity": "sha512-XtmDN5w+vdFTBZaYhdJAbMqn0DP/EhkUaAeo963mojwpKMMbw6nivtFKw07D7DDOH745L5k0VL0P8KRYNEVF/g==",
 			"requires": {
-				"@types/http-proxy": "^1.17.5",
+				"@types/http-proxy": "^1.17.8",
 				"http-proxy": "^1.18.1",
 				"is-glob": "^4.0.1",
 				"is-plain-obj": "^3.0.0",
@@ -13969,11 +13972,11 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-			"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"requires": {
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
@@ -15046,9 +15049,9 @@
 			}
 		},
 		"webpack": {
-			"version": "5.66.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.66.0.tgz",
-			"integrity": "sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==",
+			"version": "5.67.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
+			"integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -15073,7 +15076,7 @@
 				"tapable": "^2.1.1",
 				"terser-webpack-plugin": "^5.1.3",
 				"watchpack": "^2.3.1",
-				"webpack-sources": "^3.2.2"
+				"webpack-sources": "^3.2.3"
 			},
 			"dependencies": {
 				"acorn": {
@@ -15105,14 +15108,14 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+			"integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.1.0",
-				"@webpack-cli/info": "^1.4.0",
-				"@webpack-cli/serve": "^1.6.0",
+				"@webpack-cli/configtest": "^1.1.1",
+				"@webpack-cli/info": "^1.4.1",
+				"@webpack-cli/serve": "^1.6.1",
 				"colorette": "^2.0.14",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",

--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/dev-tools",
-			"version": "3.0.4",
+			"version": "3.0.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"chai": "^4.2.0",
@@ -213,14 +213,15 @@
 			"dev": true
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -706,6 +707,14 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"node_modules/loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dependencies": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.51.0",
@@ -1401,14 +1410,15 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -1801,6 +1811,14 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"mime-db": {
 			"version": "1.51.0",

--- a/plugins/dev-tools/src/debugRenderer.js
+++ b/plugins/dev-tools/src/debugRenderer.js
@@ -191,8 +191,6 @@ export class DebugRenderer {
    * share the same colours, as do previous and next.  When positioned correctly
    * a connected pair will look like a bullseye.
    * @param {Blockly.RenderedConnection} conn The connection to circle.
-   * @suppress {visibility} Suppress visibility of conn.offsetInBlock_ since
-   *     this is a debug module.
    * @package
    */
   drawConnection(conn) {

--- a/plugins/disable-top-blocks/package-lock.json
+++ b/plugins/disable-top-blocks/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/disable-top-blocks",
-			"version": "0.1.24",
+			"version": "0.1.25",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/eslint-config/package-lock.json
+++ b/plugins/eslint-config/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/eslint-config",
-			"version": "2.1.6",
+			"version": "2.1.7",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript-eslint/eslint-plugin": "^5.0.0",
@@ -125,9 +125,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
-			"integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
+			"version": "7.16.12",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+			"integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -181,13 +181,13 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.17.0.tgz",
-			"integrity": "sha512-B8DIIWE194KyQFPojUs+THa2XX+1vulwTBjirw6GqcxjtNE60Rreex26svBnV9SNLTuz92ctZx5XQE1H7yOxgA==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
+			"integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
 			"dependencies": {
 				"comment-parser": "1.3.0",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.1"
+				"jsdoc-type-pratt-parser": "~2.2.2"
 			},
 			"engines": {
 				"node": "^12 || ^14 || ^16 || ^17"
@@ -295,13 +295,13 @@
 			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-			"integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
+			"integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.10.0",
-				"@typescript-eslint/type-utils": "5.10.0",
-				"@typescript-eslint/utils": "5.10.0",
+				"@typescript-eslint/scope-manager": "5.10.1",
+				"@typescript-eslint/type-utils": "5.10.1",
+				"@typescript-eslint/utils": "5.10.1",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -327,11 +327,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
-			"integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
+			"integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
 			"dependencies": {
-				"@typescript-eslint/utils": "5.10.0",
+				"@typescript-eslint/utils": "5.10.1",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			},
@@ -352,14 +352,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-			"integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
+			"integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.10.0",
-				"@typescript-eslint/types": "5.10.0",
-				"@typescript-eslint/typescript-estree": "5.10.0",
+				"@typescript-eslint/scope-manager": "5.10.1",
+				"@typescript-eslint/types": "5.10.1",
+				"@typescript-eslint/typescript-estree": "5.10.1",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -400,13 +400,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
-			"integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
+			"integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.10.0",
-				"@typescript-eslint/types": "5.10.0",
-				"@typescript-eslint/typescript-estree": "5.10.0",
+				"@typescript-eslint/scope-manager": "5.10.1",
+				"@typescript-eslint/types": "5.10.1",
+				"@typescript-eslint/typescript-estree": "5.10.1",
 				"debug": "^4.3.2"
 			},
 			"engines": {
@@ -426,12 +426,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
-			"integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
+			"integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.10.0",
-				"@typescript-eslint/visitor-keys": "5.10.0"
+				"@typescript-eslint/types": "5.10.1",
+				"@typescript-eslint/visitor-keys": "5.10.1"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -442,9 +442,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
-			"integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
+			"integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -454,12 +454,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
-			"integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
+			"integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.10.0",
-				"@typescript-eslint/visitor-keys": "5.10.0",
+				"@typescript-eslint/types": "5.10.1",
+				"@typescript-eslint/visitor-keys": "5.10.1",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -480,11 +480,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
-			"integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
+			"integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.10.0",
+				"@typescript-eslint/types": "5.10.1",
 				"eslint-visitor-keys": "^3.0.0"
 			},
 			"engines": {
@@ -845,11 +845,11 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "37.6.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.6.1.tgz",
-			"integrity": "sha512-Y9UhH9BQD40A9P1NOxj59KrSLZb9qzsqYkLCZv30bNeJ7C9eaumTWhh9beiGqvK7m821Hj1dTsZ5LOaFIUTeTg==",
+			"version": "37.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.0.tgz",
+			"integrity": "sha512-vzy3/ltXoGtabRnjLogaEmhGxxIv5B8HK5MJLIrdxFJUvhBppZjuVuLr71DjIBi0jg6bFomwkYKjojt29cN8PA==",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.17.0",
+				"@es-joy/jsdoccomment": "~0.18.0",
 				"comment-parser": "1.3.0",
 				"debug": "^4.3.3",
 				"escape-string-regexp": "^4.0.0",
@@ -1213,9 +1213,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"peer": true
 		},
 		"node_modules/fs.realpath": {
@@ -1696,11 +1696,11 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-			"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dependencies": {
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -2199,9 +2199,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
-			"integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ=="
+			"version": "7.16.12",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+			"integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
 		},
 		"@babel/template": {
 			"version": "7.16.7",
@@ -2240,13 +2240,13 @@
 			}
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.17.0.tgz",
-			"integrity": "sha512-B8DIIWE194KyQFPojUs+THa2XX+1vulwTBjirw6GqcxjtNE60Rreex26svBnV9SNLTuz92ctZx5XQE1H7yOxgA==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
+			"integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
 			"requires": {
 				"comment-parser": "1.3.0",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.1"
+				"jsdoc-type-pratt-parser": "~2.2.2"
 			}
 		},
 		"@eslint/eslintrc": {
@@ -2329,13 +2329,13 @@
 			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-			"integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
+			"integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.10.0",
-				"@typescript-eslint/type-utils": "5.10.0",
-				"@typescript-eslint/utils": "5.10.0",
+				"@typescript-eslint/scope-manager": "5.10.1",
+				"@typescript-eslint/type-utils": "5.10.1",
+				"@typescript-eslint/utils": "5.10.1",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -2345,24 +2345,24 @@
 			},
 			"dependencies": {
 				"@typescript-eslint/type-utils": {
-					"version": "5.10.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
-					"integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
+					"version": "5.10.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
+					"integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
 					"requires": {
-						"@typescript-eslint/utils": "5.10.0",
+						"@typescript-eslint/utils": "5.10.1",
 						"debug": "^4.3.2",
 						"tsutils": "^3.21.0"
 					}
 				},
 				"@typescript-eslint/utils": {
-					"version": "5.10.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-					"integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
+					"version": "5.10.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
+					"integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
 					"requires": {
 						"@types/json-schema": "^7.0.9",
-						"@typescript-eslint/scope-manager": "5.10.0",
-						"@typescript-eslint/types": "5.10.0",
-						"@typescript-eslint/typescript-estree": "5.10.0",
+						"@typescript-eslint/scope-manager": "5.10.1",
+						"@typescript-eslint/types": "5.10.1",
+						"@typescript-eslint/typescript-estree": "5.10.1",
 						"eslint-scope": "^5.1.1",
 						"eslint-utils": "^3.0.0"
 					},
@@ -2385,37 +2385,37 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
-			"integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
+			"integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.10.0",
-				"@typescript-eslint/types": "5.10.0",
-				"@typescript-eslint/typescript-estree": "5.10.0",
+				"@typescript-eslint/scope-manager": "5.10.1",
+				"@typescript-eslint/types": "5.10.1",
+				"@typescript-eslint/typescript-estree": "5.10.1",
 				"debug": "^4.3.2"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
-			"integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
+			"integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
 			"requires": {
-				"@typescript-eslint/types": "5.10.0",
-				"@typescript-eslint/visitor-keys": "5.10.0"
+				"@typescript-eslint/types": "5.10.1",
+				"@typescript-eslint/visitor-keys": "5.10.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
-			"integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ=="
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
+			"integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q=="
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
-			"integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
+			"integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
 			"requires": {
-				"@typescript-eslint/types": "5.10.0",
-				"@typescript-eslint/visitor-keys": "5.10.0",
+				"@typescript-eslint/types": "5.10.1",
+				"@typescript-eslint/visitor-keys": "5.10.1",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -2424,11 +2424,11 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
-			"integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
+			"integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
 			"requires": {
-				"@typescript-eslint/types": "5.10.0",
+				"@typescript-eslint/types": "5.10.1",
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},
@@ -2785,11 +2785,11 @@
 			"requires": {}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "37.6.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.6.1.tgz",
-			"integrity": "sha512-Y9UhH9BQD40A9P1NOxj59KrSLZb9qzsqYkLCZv30bNeJ7C9eaumTWhh9beiGqvK7m821Hj1dTsZ5LOaFIUTeTg==",
+			"version": "37.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.0.tgz",
+			"integrity": "sha512-vzy3/ltXoGtabRnjLogaEmhGxxIv5B8HK5MJLIrdxFJUvhBppZjuVuLr71DjIBi0jg6bFomwkYKjojt29cN8PA==",
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.17.0",
+				"@es-joy/jsdoccomment": "~0.18.0",
 				"comment-parser": "1.3.0",
 				"debug": "^4.3.3",
 				"escape-string-regexp": "^4.0.0",
@@ -2969,9 +2969,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"peer": true
 		},
 		"fs.realpath": {
@@ -3318,11 +3318,11 @@
 			"peer": true
 		},
 		"resolve": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-			"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"requires": {
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}

--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/field-date",
-			"version": "5.0.4",
+			"version": "5.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",
@@ -679,7 +679,7 @@
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
 			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-			"deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
+			"deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
 			"dev": true,
 			"dependencies": {
 				"anymatch": "^2.0.0",
@@ -4003,12 +4003,12 @@
 			"dev": true
 		},
 		"node_modules/resolve": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-			"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -8604,12 +8604,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-			"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}

--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -414,7 +414,6 @@ goog.getMsgOrig = goog.getMsg;
  * @param {string} str Translatable string, places holders in the form {$foo}.
  * @param {Object.<string, string>=} values Maps place holder name to value.
  * @return {string} Message with placeholders filled.
- * @suppress {duplicate}
  */
 goog.getMsg = function(str, values = undefined) {
   const key = goog.getMsg.blocklyMsgMap[str];

--- a/plugins/field-grid-dropdown/package-lock.json
+++ b/plugins/field-grid-dropdown/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/field-grid-dropdown",
-			"version": "1.0.29",
+			"version": "1.0.30",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/field-slider/package-lock.json
+++ b/plugins/field-slider/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/field-slider",
-			"version": "3.0.4",
+			"version": "3.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",
@@ -205,15 +205,16 @@
 			"dev": true
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -692,6 +693,15 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"node_modules/loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.51.0",
@@ -1387,15 +1397,16 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -1781,6 +1792,15 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"mime-db": {
 			"version": "1.51.0",

--- a/plugins/fixed-edges/package-lock.json
+++ b/plugins/fixed-edges/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/fixed-edges",
-			"version": "1.0.22",
+			"version": "1.0.23",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/keyboard-navigation",
-			"version": "0.2.4",
+			"version": "0.2.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",
@@ -563,15 +563,16 @@
 			"dev": true
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -1846,6 +1847,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.0"
 			}
 		},
 		"node_modules/mime-db": {
@@ -3459,15 +3469,16 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -4422,6 +4433,15 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2"
+			}
+		},
+		"loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
 			}
 		},
 		"mime-db": {

--- a/plugins/modal/package-lock.json
+++ b/plugins/modal/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-modal",
-			"version": "3.0.4",
+			"version": "3.0.5",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",

--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-scroll-options",
-			"version": "2.0.4",
+			"version": "2.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/serialize-disabled-interactions/package-lock.json
+++ b/plugins/serialize-disabled-interactions/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-serialize-disabled-interactions",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.1",
@@ -169,15 +169,16 @@
 			"dev": true
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -620,6 +621,15 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"node_modules/loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.51.0",
@@ -1228,15 +1238,16 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -1592,6 +1603,15 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"mime-db": {
 			"version": "1.51.0",

--- a/plugins/strict-connection-checker/package-lock.json
+++ b/plugins/strict-connection-checker/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-strict-connection-checker",
-			"version": "1.0.29",
+			"version": "1.0.30",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",
@@ -169,15 +169,16 @@
 			"dev": true
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -620,6 +621,15 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"node_modules/loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.51.0",
@@ -1228,15 +1238,16 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -1592,6 +1603,15 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"loupe": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
+			"integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
 		},
 		"mime-db": {
 			"version": "1.51.0",

--- a/plugins/theme-dark/package-lock.json
+++ b/plugins/theme-dark/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-dark",
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"
@@ -138,9 +138,9 @@
 			}
 		},
 		"node_modules/blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"dependencies": {
 				"jsdom": "15.2.1"
@@ -660,9 +660,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
@@ -808,9 +808,9 @@
 			}
 		},
 		"node_modules/sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"dependencies": {
 				"asn1": "~0.2.3",
@@ -1126,9 +1126,9 @@
 			}
 		},
 		"blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"requires": {
 				"jsdom": "15.2.1"
@@ -1555,9 +1555,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"request": {
@@ -1661,9 +1661,9 @@
 			"optional": true
 		},
 		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",

--- a/plugins/theme-deuteranopia/package-lock.json
+++ b/plugins/theme-deuteranopia/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-deuteranopia",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"
@@ -138,9 +138,9 @@
 			}
 		},
 		"node_modules/blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"dependencies": {
 				"jsdom": "15.2.1"
@@ -660,9 +660,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
@@ -808,9 +808,9 @@
 			}
 		},
 		"node_modules/sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"dependencies": {
 				"asn1": "~0.2.3",
@@ -1126,9 +1126,9 @@
 			}
 		},
 		"blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"requires": {
 				"jsdom": "15.2.1"
@@ -1555,9 +1555,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"request": {
@@ -1661,9 +1661,9 @@
 			"optional": true
 		},
 		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",

--- a/plugins/theme-highcontrast/package-lock.json
+++ b/plugins/theme-highcontrast/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-highcontrast",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"
@@ -138,9 +138,9 @@
 			}
 		},
 		"node_modules/blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"dependencies": {
 				"jsdom": "15.2.1"
@@ -660,9 +660,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
@@ -808,9 +808,9 @@
 			}
 		},
 		"node_modules/sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"dependencies": {
 				"asn1": "~0.2.3",
@@ -1126,9 +1126,9 @@
 			}
 		},
 		"blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"requires": {
 				"jsdom": "15.2.1"
@@ -1555,9 +1555,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"request": {
@@ -1661,9 +1661,9 @@
 			"optional": true
 		},
 		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",

--- a/plugins/theme-modern/package-lock.json
+++ b/plugins/theme-modern/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-modern",
-			"version": "2.1.26",
+			"version": "2.1.27",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/theme-tritanopia/package-lock.json
+++ b/plugins/theme-tritanopia/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-tritanopia",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"
@@ -138,9 +138,9 @@
 			}
 		},
 		"node_modules/blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"dependencies": {
 				"jsdom": "15.2.1"
@@ -660,9 +660,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
@@ -808,9 +808,9 @@
 			}
 		},
 		"node_modules/sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"dependencies": {
 				"asn1": "~0.2.3",
@@ -1126,9 +1126,9 @@
 			}
 		},
 		"blockly": {
-			"version": "7.20211209.0",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.0.tgz",
-			"integrity": "sha512-6dti2yvn5tiSQZv45PtHCjdQ53dYjruG8xgCSULExsrIGAx/Yp+tD3glid7pk5DXdoFU3ck01wwEVPMoZ3JbGw==",
+			"version": "7.20211209.2",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
+			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
 			"dev": true,
 			"requires": {
 				"jsdom": "15.2.1"
@@ -1555,9 +1555,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"request": {
@@ -1661,9 +1661,9 @@
 			"optional": true
 		},
 		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",

--- a/plugins/typed-variable-modal/package-lock.json
+++ b/plugins/typed-variable-modal/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-typed-variable-modal",
-			"version": "4.0.4",
+			"version": "4.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/workspace-backpack",
-			"version": "1.0.13",
+			"version": "1.0.14",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"

--- a/plugins/workspace-search/package-lock.json
+++ b/plugins/workspace-search/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-workspace-search",
-			"version": "5.0.4",
+			"version": "5.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0",

--- a/plugins/zoom-to-fit/package-lock.json
+++ b/plugins/zoom-to-fit/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/zoom-to-fit",
-			"version": "2.0.13",
+			"version": "2.0.14",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^7.20211209.0"


### PR DESCRIPTION
1. Lerna does not automatically update the version of `@blockly/eslint-config` in the root level because I guess the root level isn't managed by lerna. This is the only plugin affected by this. This is the cause of those "visibility is not a type" lint warnings, which are fixed in the updated version of `eslint-plugin-jsdoc` which is required in the newest version of eslint-config but wasn't being pulled in. So I updated it.
2. Removed the 2 `@suppress` annotations. These are for suppressing errors in the Closure compiler which we don't use in samples. They were probably left over from when we pulled stuff out of core. The reason this is related to the first change is because it's the suppress annotations that were throwing the warning that I was trying to deal with in 1
3. As part of trying to get the version to update I deleted all the package locks and recreated them so idk here they are, enjoy. I think the version numbers themselves got updated after the recent release
4. As of this moment there are no lint errors or warnings in samples. Savor the feeling!