### PR TITLE
fix: horizontal scrolling enabled when dragging blocks

### DIFF
--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -145,6 +145,12 @@ export class ScrollOptions {
 
     // Figure out the desired location to scroll to.
     const scrollDelta = Blockly.browserEvents.getScrollDeltaPixels(e);
+    if (e.shiftKey) {
+      // Scroll horizontally (based on vertical scroll delta).
+      const temp = scrollDelta.x;
+      scrollDelta.x = scrollDelta.y;
+      scrollDelta.y = temp;
+    }
     const x = this.workspace_.scrollX - scrollDelta.x;
     const y = this.workspace_.scrollY - scrollDelta.y;
 


### PR DESCRIPTION
Fixes #1443
Where: scroll-options plugin
Testing: I reran the reproduction steps from #1443 and observed that horizontal scrolling was enabled. I also made sure to preserve the correct scrolling direction by comparing the horizontal scroll with and without dragging a block.