### PR TITLE
chore: Change setEnabled to setDisabledReason

### DIFF
--- a/codelabs/validation_and_warnings/validation_and_warnings.md
+++ b/codelabs/validation_and_warnings/validation_and_warnings.md
@@ -239,7 +239,7 @@ Depending on the severity of the issue, this might be sufficient for your custom
 
 ![A Blockly workspace with disabled break and continue blocks.](disabled_break.png)
 
-You can disable a block using `this.setEnabled(false)`, although there are some caveats: disabled blocks can't be dragged out of the toolbox flyout, and the act of disabling a block usually adds an event to Blockly's undo history. That's probably not the behavior you want when validating a block, so you can avoid both of these effects with the following code, which you should put inside the change listener function after setting the warning text:
+You can disable a block using `this.setDisabledReason(true, 'reason')`, although there are some caveats: disabled blocks can't be dragged out of the toolbox flyout, and the act of disabling a block usually adds an event to Blockly's undo history. That's probably not the behavior you want when validating a block, so you can avoid both of these effects with the following code, which you should put inside the change listener function after setting the warning text:
 
 ```js
     // Disable invalid blocks (unless it's in a toolbox flyout,
@@ -248,7 +248,7 @@ You can disable a block using `this.setEnabled(false)`, although there are some 
       const initialGroup = Blockly.Events.getGroup();
       // Make it so the move and the disable event get undone together.
       Blockly.Events.setGroup(event.group);
-      this.setEnabled(valid);
+      this.setDisabledReason(!valid, 'Invalid range');
       Blockly.Events.setGroup(initialGroup);
     }
 ```

--- a/examples/validation-and-warnings-codelab/complete-code/index.js
+++ b/examples/validation-and-warnings-codelab/complete-code/index.js
@@ -50,7 +50,7 @@ Blockly.Extensions.register('list_range_validation', function () {
       const initialGroup = Blockly.Events.getGroup();
       // Make it so the move and the disable event get undone together.
       Blockly.Events.setGroup(event.group);
-      this.setEnabled(valid);
+      this.setDisabledReason(!valid, 'Invalid range');
       Blockly.Events.setGroup(initialGroup);
     }
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

In v12, we replaced Block.setEnabled with Block.setDisabledReason. The "Validating Blocks and Displaying a Warning Indicator" codelab still uses setEnabled.

### Proposed Changes

Change the codelab text and solution of the "Validating Blocks and Displaying a Warning Indicator" codelab to use setDisabledReason.

### Reason for Changes

Codelab doesn't disable block with invalid range like it is supposed to.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

The codelab doc is updated in this PR.

### Additional Information

<!-- Anything else we should know? -->
