### PR TITLE
chore: update blocklyToolboxContents => blocklyToolboxCategoryGroup

### DIFF
--- a/codelabs/custom_toolbox/custom_toolbox.md
+++ b/codelabs/custom_toolbox/custom_toolbox.md
@@ -174,7 +174,7 @@ Copy and paste the following CSS into your `toolbox_style.css` file.
   color: white;
 }
 /* Adds padding around the group of categories and separators. */
-.blocklyToolboxContents {
+.blocklyToolboxCategoryGroup {
   padding: 0.5em;
 }
 /* Adds space between the categories, rounds the corners and adds space around the label. */

--- a/examples/custom-toolbox-codelab/complete-code/toolbox_style.css
+++ b/examples/custom-toolbox-codelab/complete-code/toolbox_style.css
@@ -3,7 +3,7 @@
   color: #fff;
 }
 /* Adds padding around the group of categories and separators. */
-.blocklyToolboxContents {
+.blocklyToolboxCategoryGroup {
   padding: 0.5em;
 }
 /* Adds space between the categories, rounds the corners and adds space around the label. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

[google/blockly issue 8344](https://github.com/google/blockly/issues/8344) renamed blocklyToolboxContents CSS class to blocklyToolboxCategoryGroup. This needs to be fixed on the custom toolbox codelab.

### Proposed Changes

Replace blocklyToolboxContents CSS class with blocklyToolboxCategoryGroup

### Reason for Changes

See above

### Test Coverage

Manually tested.

### Documentation

Codelab doc updated

### Additional Information

<!-- Anything else we should know? -->
