### PR TITLE
fix: Use getTextWidth instead of getFastTextWidth

### DIFF
--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -312,12 +312,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     let totalHeight = 0;
     for (let i = 0; i < nodes.length; i++) {
       const tspan = nodes[i] as SVGTextElement;
-      const textWidth = Blockly.utils.dom.getFastTextWidth(
-        tspan,
-        fontSize,
-        fontWeight,
-        fontFamily,
-      );
+      const textWidth = Blockly.utils.dom.getTextWidth(tspan);
       if (textWidth > totalWidth) {
         totalWidth = textWidth;
       }
@@ -345,12 +340,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
           );
         }
         dummyTextElement.textContent = actualEditorLines[i];
-        const lineWidth = Blockly.utils.dom.getFastTextWidth(
-          dummyTextElement,
-          fontSize,
-          fontWeight,
-          fontFamily,
-        );
+        const lineWidth = Blockly.utils.dom.getTextWidth(dummyTextElement);
         if (lineWidth > totalWidth) {
           totalWidth = lineWidth;
         }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes [2626](https://github.com/google/blockly-samples/issues/2626)

### Proposed Changes

In multiline input field plugin, replace two occurrences of getFastTextWidth with getTextWidth

### Reason for Changes

[Issue 8377](https://github.com/google/blockly/issues/8277) says to replace getFastTextWidth with getTextWidth

### Test Coverage

Ran `npm test`. Manually tested in test block.

### Documentation

N/A

### Additional Information

<!-- Anything else we should know? -->
