### PR TITLE
fix: In continuous toolbox plugin, replace blocklyTreeLabel with blocklyToolboxCategoryLabel

### DIFF
--- a/plugins/continuous-toolbox/src/index.ts
+++ b/plugins/continuous-toolbox/src/index.ts
@@ -82,7 +82,7 @@ export function registerContinuousToolbox() {
     display: flex;
     flex-direction: column;
   }
-  .blocklyTreeLabel {
+  .blocklyToolboxCategoryLabel {
     margin: auto;
   }
   .blocklyToolboxCategoryLabel {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes [issue 2625](https://github.com/google/blockly-samples/issues/2625)

### Proposed Changes

In continuous toolbox plugin, replace blocklyTreeLabel with blocklyToolboxCategoryLabel

### Reason for Changes

In v12, blocklyTreeLabel was replaced by blocklyToolboxCategoryLabel

### Test Coverage

Tested manually

### Documentation

N/A

### Additional Information

<!-- Anything else we should know? -->
