### PR TITLE
chore: Update turtle demo for v12

### DIFF
--- a/examples/turtle-field-demo/field_turtle.js
+++ b/examples/turtle-field-demo/field_turtle.js
@@ -15,12 +15,6 @@ class FieldTurtle extends Blockly.Field {
   // (for backwards compatibility reasons serializable is false by default).
   SERIALIZABLE = true;
 
-  // The cursor property defines what the mouse will look like when the user
-  // hovers over the field. By default the cursor will be whatever
-  // .blocklyDraggable's cursor is defined as (vis. grab). Most fields define
-  // this property as 'default'.
-  CURSOR = 'pointer';
-
   // How far to move the text to keep it to the right of the turtle.
   // May change if the turtle gets fancy enough.
   TEXT_OFFSET_X = 80;
@@ -90,31 +84,14 @@ class FieldTurtle extends Blockly.Field {
     // textElement_ (text) we can call the super-function. If we only wanted
     // one or the other, we could call their individual createX functions.
     super.initView();
+    if (this.fieldGroup_) {
+      Blockly.utils.dom.addClass(this.fieldGroup_, 'turtleField');
+    }
 
     // Note that the field group is created by the abstract field's init_
     // function. This means that *all elements* should be children of the
     // fieldGroup_.
     this.createView_();
-  }
-
-  // Updates how the field looks depending on if it is editable or not.
-  updateEditable() {
-    if (!this.fieldGroup_) {
-      // Not initialized yet.
-      return;
-    }
-    // The default functionality just makes it so the borderRect_ does not
-    // highlight when hovered.
-    super.updateEditable();
-    // Things like this are best applied to the clickTarget_. By default the
-    // click target is the same as getSvgRoot, which by default is the
-    // fieldGroup_.
-    const group = this.getClickTarget_();
-    if (!this.isCurrentlyEditable()) {
-      group.style.cursor = 'not-allowed';
-    } else {
-      group.style.cursor = this.CURSOR;
-    }
   }
 
   // Gets the text to display when the block is collapsed
@@ -403,7 +380,7 @@ class FieldTurtle extends Blockly.Field {
     };
 
     const widget = document.createElement('div');
-    widget.className = 'customFieldsTurtleWidget blocklyNonSelectable';
+    widget.className = 'customFieldsTurtleWidget';
 
     const table = document.createElement('div');
     table.className = 'table';

--- a/examples/turtle-field-demo/index.html
+++ b/examples/turtle-field-demo/index.html
@@ -116,7 +116,7 @@
       function toggleEnabled() {
         var blocks = workspace.getAllBlocks(false);
         for (var i = 0, block; (block = blocks[i]); i++) {
-          block.setEnabled(!block.isEnabled());
+          block.setDisabledReason(block.isEnabled(), 'Toggle block enabled');
         }
       }
 

--- a/examples/turtle-field-demo/turtle.css
+++ b/examples/turtle-field-demo/turtle.css
@@ -6,6 +6,9 @@
 
 .customFieldsTurtleWidget {
   width: 150px;
+  user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
 }
 
 .customFieldsTurtleWidget button {
@@ -42,7 +45,15 @@
   width: 100%;
 }
 
-.blocklySvg .blocklyNonEditableText text,
-.blocklySvg .blocklyEditableText text {
+.turtleField.blocklyEditableField {
+  cursor: pointer;
+}
+
+.turtleField.blocklyNonEditableField {
+  cursor: not-allowed;
+}
+
+.blocklySvg .blocklyNonEditableField .blocklyFieldText,
+.blocklySvg .blocklyEditableField .blocklyFieldText {
   fill: #000;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes [issue 2628](https://github.com/google/blockly-samples/issues/2628).

### Proposed Changes

Makes the following fixes to address the problems in the bug:

*   Sets the cursor using CSS.
    *   In `FieldTurtle`, removes the `CURSOR` field, removes `updateEditable()` (which only set the cursor), and adds a `turtleField` class for greater specificity.
    *   In the CSS, sets the cursor type.

*   Updates CSS names for v12: Changes `blocklyEditableText` to `blocklyEditableField` and `blocklyNonEditableText` to `blocklyNonEditableField`.

*   In the CSS file, deletes `.blocklyNonSelectable` (removed in v12) and moves its rules to `customFieldsTurtleWidget`.

Makes the following changes, which address other problems:

*   Replaces call to `Block.setEnabled` (removed in v12) with call to `Block.setDisabledReason`.

*   Fixes the final set of CSS selectors, which weren't being applied because the `text` selector was less specific than the `.blocklyText` selector in `.geras-renderer.classic-theme .blocklyText`, which comes from `renderers/common/constants.ts`. As a result, the fill was set to `#fff` instead of `#000`, which the final set of selectors attempted to apply.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested manually

### Documentation

N/A

### Additional Information

<!-- Anything else we should know? -->
