### PR TITLE
chore: In block-tests plugin, replace setEnabled with setDisabledReason

### DIFF
--- a/plugins/block-test/src/fields/defaults.js
+++ b/plugins/block-test/src/fields/defaults.js
@@ -234,7 +234,7 @@ export function onInit(workspace) {
       .getWorkspace()
       .getAllBlocks(false);
     for (let i = 0, block; (block = blocks[i]); i++) {
-      block.setEnabled(!block.isEnabled());
+      block.setDisabledReason(block.isEnabled(), 'Toggle block enabled');
     }
   };
   const toggleShadow = function (button) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Replaces Block.setEnabled (removed in v12) with Block.setDisabledReason.

### Proposed Changes

Replaces Block.setEnabled with Block.setDisabledReason.

### Reason for Changes

Block.setEnabled removed in v12.

### Test Coverage

Tested manually

### Documentation

N/A

### Additional Information

<!-- Anything else we should know? -->
