### PR TITLE
fix: Update README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">
-Blockly Samples <br /> <a href="https://github.com/google/blockly"><img src="https://tinyurl.com/built-on-blockly" /> </a>
+Blockly Samples <br /> <a href="https://github.com/RaspberryPiFoundation/blockly"><img src="https://tinyurl.com/built-on-blockly" /> </a>
 </h1>
 
-Plugins, codelabs, and examples related to the [Blockly](https://github.com/google/blockly) library.
+Plugins, codelabs, and examples related to the [Blockly](https://github.com/RaspberryPiFoundation/blockly) library.
 
 This repository has three sections:
 
@@ -10,7 +10,7 @@ This repository has three sections:
 - [Examples](examples/): self-contained sample projects demonstrating techniques to include and extend the Blockly library.
 - [Codelabs](codelabs/): interactive tutorials demonstrating how to use Blockly.
 
-Please see our [GitHub Pages site](https://google.github.io/blockly-samples/index.html) for interactive demos of most plugins.
+Please see our [GitHub Pages site](https://raspberrypifoundation.github.io/blockly-samples/index.html) for interactive demos of most plugins.
 
 ## Support
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

No issue filed for this.

### Proposed Changes

Updates the README to point to the correct new links

### Reason for Changes

While GitHub links automatically redirect, GitHub Pages do not and the old link may cause confusion for people who try using it.

### Test Coverage

I clicked on the link to make sure it works.

### Documentation

This is documentation.

### Additional Information

None.