### PR TITLE
chore: update publish and ghpages workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,15 @@ on:
     - cron: '5 17 * * 4' # Thursdays at 17:05 UTC (09:05 PST / 10:05 PDT)
 
 permissions:
+  id-token: write # Required for OIDC.
   contents: write # For checkout and tag.
   packages: write # For publish.
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Don't try to publish from a fork of google/blockly-samples.
-    if: ${{ github.repository_owner == 'google' }}
+    # Don't try to publish from a fork of RaspberryPiFoundation/blockly-samples.
+    if: ${{ github.repository_owner == 'RaspberryPiFoundation' }}
 
     # Environment specific to releasing so we can isolate the npm token.
     environment: release
@@ -26,7 +27,7 @@ jobs:
         # fetch all tags and commits so that lerna can version appropriately
         with:
           fetch-depth: 0
-          ref: 'master'
+          ref: 'main'
 
       # This uses a reverse-engineered email for the github actions bot. See
       # https://github.com/actions/checkout/issues/13#issuecomment-724415212
@@ -39,11 +40,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-
-      - name: Configure npm
-        run: npm config set //wombat-dressing-room.appspot.com/:_authToken=$NODE_AUTH_TOKEN
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.RELEASE_BACKED_NPM_TOKEN }}
 
       - name: NPM install
         # Use CI so that we don't update dependencies in this step.
@@ -64,6 +60,6 @@ jobs:
     name: Update GitHub Pages
     # Call the Update gh-pages workflow only if publishing succeeds
     needs: [publish]
-    # Don't try to auto-update if on a fork of google/blockly-samples.
-    if: ${{ github.repository_owner == 'google' }}
+    # Don't try to auto-update if on a fork of RaspberryPiFoundation/blockly-samples.
+    if: ${{ github.repository_owner == 'RaspberryPiFoundation' }}
     uses: ./.github/workflows/update_gh_pages.yml

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -8,7 +8,7 @@ on:
       branch:
         description: 'Branch to publish from'
         required: true
-        default: 'master'
+        default: 'main'
         type: string
   workflow_call: # Allow this workflow to be called from publish workflow.
 
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.branch || 'master' }}
+          ref: ${{ inputs.branch || 'main' }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,7 +66,7 @@ function prepareForPublish(done) {
       `${path.resolve(releaseDir)}`,
   );
   execSync(
-    `git clone https://github.com/google/blockly-samples ${releaseDir}`,
+    `git clone https://github.com/RaspberryPiFoundation/blockly-samples ${releaseDir}`,
     {stdio: 'pipe'},
   );
 
@@ -84,7 +84,7 @@ function prepareForPublish(done) {
 
   // Login to npm.
   console.log('Logging in to npm.');
-  execSync(`npm login --registry https://wombat-dressing-room.appspot.com`, {
+  execSync(`npm login`, {
     stdio: 'inherit',
   });
   done();
@@ -304,7 +304,9 @@ function deployToGhPagesOrigin(done) {
  * @returns {Function} Gulp task.
  */
 function deployToGhPagesUpstream(done) {
-  return deployToGhPages('https://github.com/google/blockly-samples.git')(done);
+  return deployToGhPages(
+    'https://github.com/RaspberryPiFoundation/blockly-samples.git',
+  )(done);
 }
 
 module.exports = {

--- a/scripts.md
+++ b/scripts.md
@@ -23,7 +23,7 @@ https://YOURUSERNAME.github.io/blockly-samples/.
 
 This script is similar to `npm run deploy` but it deploys the plugins to
 `blockly-samples` upstream. You can browse these plugin playgrounds at:
-https://google.github.io/blockly-samples/.
+https://raspberrypifoundation.github.io/blockly-samples/.
 
 ### `npm run license`
 

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -69,15 +69,15 @@ function injectFooter(initialContents) {
         <ul>
           <li><a target="_blank" href="https://developers.google.com/blockly/guides/overview/">Developer Docs</a></li>
           <li><a target="_blank" href="https://blocklycodelabs.dev/">Codelabs</a></li>
-          <li><a target="_blank" href="https://google.github.io/blockly-samples/developer-tools/index.html">Developer
+          <li><a target="_blank" href="https://raspberrypifoundation.github.io/blockly-samples/developer-tools/index.html">Developer
               Tools</a></li>
         </ul>
       </div>
       <div class="link-list">
         <label>Github</label>
         <ul>
-          <li><a target="_blank" href="https://github.com/google/blockly/">Blockly Sources</a></li>
-          <li><a target="_blank" href="https://github.com/google/blockly-samples/">Blockly Samples</a></li>
+          <li><a target="_blank" href="https://github.com/raspberrypifoundation/blockly/">Blockly Sources</a></li>
+          <li><a target="_blank" href="https://github.com/raspberrypifoundation/blockly-samples/">Blockly Samples</a></li>
         </ul>
       </div>
       <div class="link-list">
@@ -107,7 +107,7 @@ function injectFooter(initialContents) {
  * @returns {string} The modified contents of the page, as a string.
  */
 function injectPluginNavBar(inputString, packageJson, pluginDir, isLocal) {
-  const codeLink = `https://github.com/google/blockly-samples/blob/master/plugins/${pluginDir}`;
+  const codeLink = `https://github.com/raspberrypifoundation/blockly-samples/blob/main/plugins/${pluginDir}`;
   const npmLink = `https://www.npmjs.com/package/${packageJson.name}`;
   const baseURL = isLocal ? '/' : '/blockly-samples/';
 
@@ -367,7 +367,7 @@ function injectExampleNavBar(inputString, demoConfig, pageRoot, isLocal) {
   const descriptionString = demoConfig.description
     ? `<div class="subtitle">${demoConfig.description}</div>`
     : ``;
-  const codeLink = `https://github.com/google/blockly-samples/blob/master/${pageRoot}`;
+  const codeLink = `https://github.com/raspberrypifoundation/blockly-samples/blob/main/${pageRoot}`;
 
   const pages = demoConfig.pages;
   const tabString = pages ? createExampleTabs(pageRoot, pages, isLocal) : '';
@@ -594,10 +594,10 @@ function createIndexPage(isLocal) {
   <!-- HEADER -->
   <nav id="toolbar">
     <div class="site-width layout horizontal">
-      <a href="https://google.github.io/blockly-samples/"><img src="https://blocklycodelabs.dev/images/logo_knockout.png" class="logo-devs"
+      <a href="https://raspberrypifoundation.github.io/blockly-samples/"><img src="https://blocklycodelabs.dev/images/logo_knockout.png" class="logo-devs"
           alt="Blockly" /></a>
     </div>
-    <a class="button" href="https://github.com/google/blockly-samples">View on GitHub</a>
+    <a class="button" href="https://github.com/raspberrypifoundation/blockly-samples">View on GitHub</a>
   </nav>
   <main id="main" class="index">
     <div class="drop-shadow"></div>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Updates the publishing workflow for the post-google world.

### Proposed Changes

- Updates the publishing workflow to use OIDC and remove references to google and wombat dressing room
- Updates the ghpages workflow and scripts to reference the `main` branch and the correct repo name

Notably:

- Does not update the publish_from_package workflow. You can only have one trusted publishing workflow set up at a time. So this workflow will need to be deleted and instead we can have an optional manual input to the main publishing workflow that would set the `from-package` option. I will do that once I verify that this basic workflow works.

### Reason for Changes

Re-enabling publishing in the post-google world.

### Test Coverage

I'll click the button and see what happens. I have run the `publish:prepare` and `publish:checkVersions` scripts locally and confirm they work as expected.

### Documentation

Internal documentation only

### Additional Information

<!-- Anything else we should know? -->
