### PR TITLE
fix: Update broken links from Google repo

### DIFF
--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -5,7 +5,7 @@
     <link
       rel="icon"
       type="image/x-icon"
-      href="https://google.github.io/blockly-samples/favicon.ico" />
+      href="https://raspberrypifoundation.github.io/blockly-samples/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blockly Developer Tools</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -50,4 +50,4 @@ Note: Updating GitHub Pages is done automatically when publishing plugins throug
         npm run deploy:upstream
         ```
 
-        Test at https://google.github.io/blockly-samples/
+        Test at https://raspberrypifoundation.github.io/blockly-samples/

--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -12,7 +12,7 @@ npm install @blockly/dev-tools -D --save
 
 ### Playground
 
-The playground is a tremendously useful tool for debugging your Blockly project. As a preview, here is [one of the plugin playgrounds](https://google.github.io/blockly-samples/plugins/theme-modern/test/). The playground features are:
+The playground is a tremendously useful tool for debugging your Blockly project. As a preview, here is [one of the plugin playgrounds](https://raspberrypifoundation.github.io/blockly-samples/plugins/theme-modern/test/). The playground features are:
 
 - All the default blocks
 - All the language generators (JavaScript, Python, PHP, Lua, and Dart)


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Proposed Changes

Fixes #2654 

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Updated links from https://google.github.io/blockly-samples/ to https://raspberrypifoundation.github.io/blockly-samples/

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The links were broken due to the repository change from Google to RaspberryPiFoundation.
