### PR TITLE
chore: add the registry URL and update actions in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         # fetch all tags and commits so that lerna can version appropriately
         with:
           fetch-depth: 0
@@ -37,9 +37,10 @@ jobs:
           git config --global user.email '<41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       - name: NPM install
         # Use CI so that we don't update dependencies in this step.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Updates the checkout and setup-node actions, and adds the registry URL option to setup node. The registry URL is in all of the examples for using OIDC so maybe it's required.