### PR TITLE
fix: reconnect procedure block statement inputs

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -361,7 +361,7 @@ const procedureDefUpdateShapeMixin = {
         this.moveInputBefore('STACK', 'RETURN');
       }
       // Restore the stack, if one was saved.
-      this.statementConnection_?.(this, 'STACK');
+      this.statementConnection_?.reconnect(this, 'STACK');
       this.statementConnection_ = null;
     } else {
       // Save the stack, then disconnect it.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2601 

### Proposed Changes

Calls reconnect on the saved statement input

### Reason for Changes

Bug fixing

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
