### PR TITLE
fix: Merge multiline text readme to with pre-v11 documentation 

### DIFF
--- a/plugins/field-multilineinput/README.md
+++ b/plugins/field-multilineinput/README.md
@@ -59,17 +59,17 @@ overwrite it.
 ### JavaScript
 
 ```js
-import * as Blockly from "blockly";
-import { registerFieldMultilineInput } from "@blockly/field-multilineinput";
+import * as Blockly from 'blockly';
+import {registerFieldMultilineInput} from '@blockly/field-multilineinput';
 
 registerFieldMultilineInput();
-Blockly.Blocks["test_field_multilineinput"] = {
+Blockly.Blocks['test_field_multilineinput'] = {
   init: function () {
     this.appendDummyInput()
-      .appendField("multilineinput: ")
+      .appendField('multilineinput: ')
       .appendField(
-        new FieldMultilineInput("some text \n with newlines"),
-        "FIELDNAME",
+        new FieldMultilineInput('some text \n with newlines'),
+        'FIELDNAME',
       );
   },
 };
@@ -167,12 +167,12 @@ function will also install the correct generator function for the
 corresponding language(s).
 
 ```js
-import { javascriptGenerator } from "blockly/javascript";
-import { dartGenerator } from "blockly/dart";
-import { phpGenerator } from "blockly/php";
-import { pythonGenerator } from "blockly/python";
-import { luaGenerator } from "blockly/lua";
-import { textMultiline } from "@blockly/field-multilineinput";
+import {javascriptGenerator} from 'blockly/javascript';
+import {dartGenerator} from 'blockly/dart';
+import {phpGenerator} from 'blockly/php';
+import {pythonGenerator} from 'blockly/python';
+import {luaGenerator} from 'blockly/lua';
+import {textMultiline} from '@blockly/field-multilineinput';
 
 // Installs the block, the field, and all of the language generators.
 textMultiline.installBlock({

--- a/plugins/field-multilineinput/README.md
+++ b/plugins/field-multilineinput/README.md
@@ -1,7 +1,7 @@
 # @blockly/field-multilineinput [![Built on Blockly](https://tinyurl.com/built-on-blockly)](https://github.com/google/blockly)
 
 A [Blockly](https://www.npmjs.com/package/blockly) multiline input field and
-  associated block.
+associated block.
 
 #### Multiline input field
 

--- a/plugins/field-multilineinput/README.md
+++ b/plugins/field-multilineinput/README.md
@@ -1,6 +1,21 @@
 # @blockly/field-multilineinput [![Built on Blockly](https://tinyurl.com/built-on-blockly)](https://github.com/google/blockly)
 
-A [Blockly](https://www.npmjs.com/package/blockly) multilineinput field and associated block.
+A [Blockly](https://www.npmjs.com/package/blockly) multiline input field and
+  associated block.
+
+#### Multiline input field
+
+![A block with the label "multiline text input:" and a multiline input field
+with the text "default text \n with newline character.](readme-media/on_block.png)
+
+#### Multiline input field with editor open
+
+![The same block with editor open.](readme-media/with_editor.png)
+
+#### Multiline input on collapsed block
+
+![The same block after being collapsed. It has the label "multiline text input:
+defau..." and a jagged right edge to show it is collapsed.](readme-media/collapsed.png)
 
 ## Installation
 
@@ -18,17 +33,23 @@ npm install @blockly/field-multilineinput --save
 
 ## Usage
 
-### Field
+This plugin adds a field of type `FieldMultilineInput` that is registered with
+the name `'field_multilinetext'`. It is a subclass of `Blockly.FieldInput`.
 
-This field accepts up to 3 parameters:
+This field stores a string as its value and a string as its text. Its value is
+always a valid string, while its text could be any string entered into its
+editor. Unlike a text input field, this field also supports newline characters
+entered in the editor.
 
-- "text" to specify the default text. Defaults to `""`.
-- "maxLines" to specify the maximum number of lines displayed before scrolling
-  functionality is enabled. Defaults to `Infinity`.
-- "spellcheck" to specify whether spell checking is enabled. Defaults to
-  `true`.
+The constructor for this field accepts three optional parameters:
 
-The multiline input field is a subclass of Blockly.FieldInput
+- `value`: The default text. Defaults to `""`.
+- `validator`: A function that is called to validate what the user entered.
+- `config`: An object with three optional properties:
+  - `maxLines`: The maximum number of lines displayed before scrolling
+    functionality is enabled. Defaults to `Infinity`.
+  - `spellcheck`: Whether spell checking is enabled. Defaults to `true`.
+  - `tooltip`: A tooltip.
 
 If you want to use only the field, you must register it with Blockly. You can
 do this by calling `registerFieldMultilineInput` before instantiating your
@@ -38,17 +59,17 @@ overwrite it.
 ### JavaScript
 
 ```js
-import * as Blockly from 'blockly';
-import {registerFieldMultilineInput} from '@blockly/field-multilineinput';
+import * as Blockly from "blockly";
+import { registerFieldMultilineInput } from "@blockly/field-multilineinput";
 
 registerFieldMultilineInput();
-Blockly.Blocks['test_field_multilineinput'] = {
+Blockly.Blocks["test_field_multilineinput"] = {
   init: function () {
     this.appendDummyInput()
-      .appendField('multilineinput: ')
+      .appendField("multilineinput: ")
       .appendField(
-        new FieldMultilineInput('some text \n with newlines'),
-        'FIELDNAME',
+        new FieldMultilineInput("some text \n with newlines"),
+        "FIELDNAME",
       );
   },
 };
@@ -74,6 +95,65 @@ Blockly.defineBlocksWithJsonArray([
     }]);
 ```
 
+### Customization
+
+#### Spellcheck
+
+The `setSpellcheck` function can be used to set whether the field spellchecks
+its input text or not. Spellchecking is on by default.
+
+![An animation showing multiline text input fields with and without
+spellcheck.](readme-media/spellcheck.gif)
+
+This applies to individual fields. If you want to modify all fields change the
+`Blockly.FieldMultilineInput.prototype.spellcheck_` property.
+
+#### Validation
+
+A multiline text input field's value is a string, so any validators must accept
+a string and return a string, `null`, or `undefined`.
+
+Here is an example of a validator that removes all 'a' characters from the
+string:
+
+```
+function(newValue) {
+  return newValue.replace(/a/gm, '');
+}
+```
+
+![An animation showing validation.](readme-media/validator.gif)
+
+### Serialization
+
+#### JSON
+
+The JSON for a multiline text input field looks like so:
+
+```json
+{
+  "fields": {
+    "FIELDNAME": "line1\nline2"
+  }
+}
+```
+
+where `FIELDNAME` is a string referencing a multiline text input field, and the
+value is the value to apply to the field. The value follows the same rules as
+the constructor value.
+
+#### XML
+
+The XML for a multiline text input field looks like so:
+
+```xml
+<field name="FIELDNAME">line1&amp;#10;line2</field>
+```
+
+where the field's `name` attribute contains a string referencing a multiline
+text input field, and the inner text is the value to apply to the field. The
+inner text value follows the same rules as the constructor value.
+
 ### Blocks
 
 This package also provides a simple block containing a multiline input
@@ -87,12 +167,12 @@ function will also install the correct generator function for the
 corresponding language(s).
 
 ```js
-import {javascriptGenerator} from 'blockly/javascript';
-import {dartGenerator} from 'blockly/dart';
-import {phpGenerator} from 'blockly/php';
-import {pythonGenerator} from 'blockly/python';
-import {luaGenerator} from 'blockly/lua';
-import {textMultiline} from '@blockly/field-multilineinput';
+import { javascriptGenerator } from "blockly/javascript";
+import { dartGenerator } from "blockly/dart";
+import { phpGenerator } from "blockly/php";
+import { pythonGenerator } from "blockly/python";
+import { luaGenerator } from "blockly/lua";
+import { textMultiline } from "@blockly/field-multilineinput";
 
 // Installs the block, the field, and all of the language generators.
 textMultiline.installBlock({


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Resolves

Fixes #2242

### Proposed Changes

Merge existing README documentation with the pre-v11 DevSite documentation for multiline text input field.

### Reason for Changes

More complete documentation.

### Test Coverage

Tested as a g3doc, but images are untested and it's unclear if they will work. I used the same strategy as the README for [@blockly/field-colour-hsv-sliders](https://www.npmjs.com/package/@blockly/field-colour-hsv-sliders?activeTab=readme), but it's not clear why that works, as the readme-media subdirectory does not appear to be on npm.

### Documentation

PR is documentation

### Additional Information

<!-- Anything else we should know? -->
