### PR TITLE
chore: add a workflow input to publish from-package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ name: publish
 
 on:
   workflow_dispatch: # Manually trigger. Colon is required.
+    inputs:
+      from-package:
+        description: 'Check to publish from-package instead of the default publish. This is used to publish packages that have already been version bumped and tagged by a previous workflow run, but failed to publish for some reason.'
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '5 17 * * 4' # Thursdays at 17:05 UTC (09:05 PST / 10:05 PDT)
 
@@ -55,7 +61,14 @@ jobs:
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cd plugins && npx lerna publish --no-private --conventional-commits --create-release github --yes
+          FROM_PACKAGE: ${{ github.event.inputs['from-package'] }}
+        run: |
+          cd plugins
+          if [ "${FROM_PACKAGE}" = "true" ]; then
+            npx lerna publish from-package --yes --loglevel silly
+          else
+            npx lerna publish --no-private --conventional-commits --create-release github --yes --loglevel silly
+          fi
 
   update-gh-pages:
     name: Update GitHub Pages


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Works on publishing blockly-samples

### Proposed Changes

- adds more logging because I can't figure out why OIDC isn't working :(
- adds a workflow option to try publishing from-package so that I can use that when publishing fails

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran this through a github actions validator

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
