### PR TITLE
fix: update plugin URLs to RPF

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 ## How can I contribute?
 
-- [Suggest](https://github.com/google/blockly-samples/issues/new?assignees=&labels=type%3A+feature+request%2C+triage&template=feature_request.md) plugins, examples, or codelabs
+- [Suggest](https://github.com/RaspberryPiFoundation/blockly-samples/issues/new?assignees=&labels=type%3A+feature+request%2C+triage&template=feature_request.md) plugins, examples, or codelabs
   - :arrow_right: Start by reading [How To Write A Good Issue](https://developers.google.com/blockly/guides/modify/contribute/write_a_good_issue)
 - Implement plugins, examples, or codelabs
   - :arrow_right: Read up on how to [Add a Plugin](https://developers.google.com/blockly/guides/modify/contribute/add_a_plugin) or [Write a Codelab](https://developers.google.com/blockly/guides/modify/contribute/write_a_codelab)
-- [Report bugs](https://github.com/google/blockly-samples/issues/new?assignees=&labels=type%3A+bug%2C+triage&template=bug_report.md)
+- [Report bugs](https://github.com/RaspberryPiFoundation/blockly-samples/issues/new?assignees=&labels=type%3A+bug%2C+triage&template=bug_report.md)
   - :arrow_right: Start by reading [How To Write A Good Issue](https://developers.google.com/blockly/guides/modify/contribute/write_a_good_issue)
 - Fix bugs
   - :arrow_right: Start by reading [Finding a Good Issue](https://developers.google.com/blockly/guides/modify/contribute/issue_labels)

--- a/codelabs/context_menu_option/context_menu_option.md
+++ b/codelabs/context_menu_option/context_menu_option.md
@@ -3,7 +3,7 @@ summary: How to add a context menu option in Blockly.
 id: context-menu-option
 categories: blockly,codelab,contextmenu
 status: Published
-Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Customizing your context menus
 
@@ -34,12 +34,12 @@ This codelab is focused on Blockly's context menus. Non-relevant concepts and co
 
 You can get the sample code for this code by either downloading the zip here:
 
-[Download zip](https://github.com/google/blockly-samples/archive/master.zip)
+[Download zip](https://github.com/RaspberryPiFoundation/blockly-samples/archive/master.zip)
 
 or by cloning this git repo:
 
 ```bash
-git clone https://github.com/google/blockly-samples.git
+git clone https://github.com/RaspberryPiFoundation/blockly-samples.git
 ```
 
 If you downloaded the source as a zip, unpacking it should give you a root folder named `blockly-samples-master`.

--- a/codelabs/css/css.md
+++ b/codelabs/css/css.md
@@ -1,6 +1,6 @@
 author: Blockly Team summary: How to use CSS in Blockly. id: css-identifier
 categories: blockly,codelab,css status: Published feedback link:
-https://github.com/google/blockly-samples/issues/new/choose
+https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Use CSS in Blockly
 

--- a/codelabs/custom_generator/custom_generator.md
+++ b/codelabs/custom_generator/custom_generator.md
@@ -3,7 +3,7 @@ summary: Codelab showing how to create and use a custom generator.
 id: custom-generator
 categories: blockly,codelab,generator
 status: Published
-Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Build a custom generator
 
@@ -43,7 +43,7 @@ Use the [`npx @blockly/create-package app`](https://www.npmjs.com/package/@block
 
 The initial application has one custom block and includes JavaScript generator definitions for that block. Since this codelab will be creating a JSON generator instead, it will remove that custom block and add its own.
 
-The complete code used in this codelab can be viewed in blockly-samples under [`examples/custom-generator-codelab`](https://github.com/google/blockly-samples/tree/master/examples/custom-generator-codelab).
+The complete code used in this codelab can be viewed in blockly-samples under [`examples/custom-generator-codelab`](https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/examples/custom-generator-codelab).
 
 Before setting up the rest of the application, change the storage key used for this codelab application. This will ensure that the workspace is saved in its own storage, separate from the regular sample app, so that it doesn't interfere with other demos. In `serialization.js`, change the value of `storageKey` to some unique string. `jsonGeneratorWorkspace` will work:
 

--- a/codelabs/custom_renderer/custom_renderer.md
+++ b/codelabs/custom_renderer/custom_renderer.md
@@ -3,7 +3,7 @@ summary: Codelab showing how to create custom renderers.
 id: custom-renderer
 categories: blockly,codelab,rendering,customization
 status: Published
-Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Build custom renderers
 
@@ -49,7 +49,7 @@ Use the Use the [`npx @blockly/create-package`](https://www.npmjs.com/package/@b
 
 The initial application uses the default renderer and contains no code or definitions for a custom renderer.
 
-The complete code used in this codelab can be viewed in blockly-samples under [`examples/custom-renderer-codelab`](https://github.com/google/blockly-samples/tree/master/examples/custom-renderer-codelab).
+The complete code used in this codelab can be viewed in blockly-samples under [`examples/custom-renderer-codelab`](https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/examples/custom-renderer-codelab).
 
 Before setting up the rest of the application, change the storage key used for this codelab application. This will ensure that the workspace is saved in its own storage, separate from the regular sample app, so that it doesn't interfere with other demos. In `serialization.js`, change the value of `storageKey` to some unique string. `customRenderersWorkspace` will work:
 

--- a/codelabs/custom_toolbox/custom_toolbox.md
+++ b/codelabs/custom_toolbox/custom_toolbox.md
@@ -3,7 +3,7 @@ summary: Codelab to customize a toolbox
 id: custom-toolbox
 categories: blockly,codelab,toolbox,customization
 status: Published
-Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Customizing a Blockly toolbox
 
@@ -27,7 +27,7 @@ The resulting toolbox is shown below.
 
 ![A toolbox with colored background and the blockly label above the category text.](./final_toolbox.png)
 
-The code samples are written in ES6 syntax. You can find the code for the [completed custom toolbox](https://github.com/google/blockly-samples/tree/master/examples/custom-toolbox-codelab/complete-code/index.html) on GitHub.
+The code samples are written in ES6 syntax. You can find the code for the [completed custom toolbox](https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/examples/custom-toolbox-codelab/complete-code/index.html) on GitHub.
 
 ### What you'll need
 - A browser.
@@ -44,12 +44,12 @@ toolbox definition that can be found in the provided code.
 ### Download the sample code
 You can get the sample code for this codelab by either downloading the zip here:
 
-[Download zip](https://github.com/google/blockly-samples/archive/master.zip)
+[Download zip](https://github.com/RaspberryPiFoundation/blockly-samples/archive/master.zip)
 
 or by cloning this git repo:
 
 ```bash
-git clone https://github.com/google/blockly-samples.git
+git clone https://github.com/RaspberryPiFoundation/blockly-samples.git
 ```
 
 If you downloaded the source as a zip, unpacking it should give you a root folder named `blockly-samples-master`.
@@ -520,4 +520,4 @@ The toolbox can be customized in a variety of ways to make it work for your appl
 * How to add an icon by adding a custom CSS class to the icon div.
 * How to change what HTML Elements are used for different parts of a category.
 * How to create a custom toolbox item.
-You can find the code for the [completed custom toolbox](https://github.com/google/blockly-samples/tree/master/examples/custom-toolbox-codelab/complete-code) on GitHub.
+You can find the code for the [completed custom toolbox](https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/examples/custom-toolbox-codelab/complete-code) on GitHub.

--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -3,7 +3,7 @@ summary: In this codelab, you’ll add Blockly editor to a simple web app, to al
 id: getting-started
 categories: blockly,codelab,quickstart
 status: Published
-Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Getting started with Blockly
 
@@ -43,12 +43,12 @@ This codelab is focused on Blockly. The app structure, non-relevant concepts and
 
 You can get the sample code for this code by either downloading the zip here:
 
-[Download zip](https://github.com/google/blockly-samples/archive/master.zip)
+[Download zip](https://github.com/RaspberryPiFoundation/blockly-samples/archive/master.zip)
 
 or by cloning this git repo:
 
 ```bash
-git clone https://github.com/google/blockly-samples.git
+git clone https://github.com/RaspberryPiFoundation/blockly-samples.git
 ```
 
 If you downloaded the source as a zip, unpacking it should give you a root folder named `blockly-samples-master`.
@@ -119,7 +119,7 @@ Importing Blockly this way loads four default modules.
 
 ### Alternate imports
 
-There are many ways to import a library in JavaScript, and this tutorial does not cover all of them. For samples that show how to integrate Blockly in your project, look at the `examples` folder in [blockly-samples](https://github.com/google/blockly-samples).
+There are many ways to import a library in JavaScript, and this tutorial does not cover all of them. For samples that show how to integrate Blockly in your project, look at the `examples` folder in [blockly-samples](https://github.com/RaspberryPiFoundation/blockly-samples).
 
 You can also define your imports more carefully to get [different generators](https://www.npmjs.com/package/blockly#blockly-generators) and [locales](https://www.npmjs.com/package/blockly#blockly-languages).
 

--- a/codelabs/sample.md
+++ b/codelabs/sample.md
@@ -6,7 +6,7 @@ categories: Blockly
 tags:
 status: Published
 authors: The Blockly Team
-Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 ---
 

--- a/codelabs/template.md
+++ b/codelabs/template.md
@@ -3,7 +3,7 @@ summary: CODELAB SUMMARY
 id: TEMPLATE-CODELAB-ID
 categories: blockly,codelab,MORE CATEGORIES
 status: Draft
-Feedback Link: https://github.com/google/blockly-samples/issues/new
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new
 
 # CODELAB TITLE
 

--- a/codelabs/theme_extension/theme_extension.md
+++ b/codelabs/theme_extension/theme_extension.md
@@ -3,7 +3,7 @@ summary: How to extend a theme in Blockly.
 id: theme-extension-identifier
 categories: blockly,codelab,theme
 status: Published
-feedback link: https://github.com/google/blockly-samples/issues/new/choose
+feedback link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Customizing your themes
 
@@ -33,12 +33,12 @@ are glossed over and provided for you to simple copy and paste.
 
 You can get the sample code for this code by either downloading the zip here:
 
-[Download zip](https://github.com/google/blockly-samples/archive/master.zip)
+[Download zip](https://github.com/RaspberryPiFoundation/blockly-samples/archive/master.zip)
 
 or by cloning this git repo:
 
 ```bash
-git clone https://github.com/google/blockly-samples.git
+git clone https://github.com/RaspberryPiFoundation/blockly-samples.git
 ```
 
 If you downloaded the source as a zip, unpacking it should give you a root folder named `blockly-samples-master`.

--- a/codelabs/validation_and_warnings/validation_and_warnings.md
+++ b/codelabs/validation_and_warnings/validation_and_warnings.md
@@ -3,7 +3,7 @@ summary: How to validate blocks and display a warning indicator for invalid bloc
 id: validation-and-warnings
 categories: blockly,codelab,validation,warning
 status: Published
-Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
+Feedback Link: https://github.com/RaspberryPiFoundation/blockly-samples/issues/new/choose
 
 # Validating Blocks and Displaying a Warning Indicator
 
@@ -19,7 +19,7 @@ In this codelab, you'll create a new custom block type that generates a list of 
 
 ![Two instances of a custom block, one with a validation warning.](./final_range_blocks.png)
 
-You can find the code for the [completed custom block](https://github.com/google/blockly-samples/tree/master/examples/validation-and-warnings-codelab/complete-code/index.js) on GitHub.
+You can find the code for the [completed custom block](https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/examples/validation-and-warnings-codelab/complete-code/index.js) on GitHub.
 
 ### What you'll need
 - A browser.
@@ -33,12 +33,12 @@ You can find the code for the [completed custom block](https://github.com/google
 ### Download the sample code
 You can get the sample code for this codelab by either downloading the zip here:
 
-[Download zip](https://github.com/google/blockly-samples/archive/master.zip)
+[Download zip](https://github.com/RaspberryPiFoundation/blockly-samples/archive/master.zip)
 
 or by cloning this git repo:
 
 ```bash
-git clone https://github.com/google/blockly-samples.git
+git clone https://github.com/RaspberryPiFoundation/blockly-samples.git
 ```
 
 If you downloaded the source as a zip, unpacking it should give you a root folder named `blockly-samples-master`.
@@ -266,7 +266,7 @@ In this codelab, you learned:
 * How to display a warning message on the block.
 * How to disable a block (without adding an event to the undo history).
 
-You can find the code for the [completed custom block](https://github.com/google/blockly-samples/tree/master/examples/validation-and-warnings-codelab/complete-code/index.js) on GitHub.
+You can find the code for the [completed custom block](https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/examples/validation-and-warnings-codelab/complete-code/index.js) on GitHub.
 
 ### Resources
 For more information related topics, check out the documentation:

--- a/examples/blockly-rtc/README.md
+++ b/examples/blockly-rtc/README.md
@@ -48,6 +48,6 @@ The UX for collaboration is based on the idea of minimal distraction. Users will
 
 Markers will be used to display the positions of other users on the workspace. Each user will have a colour assigned to them. Currently markers show when a user has selected a block or is editing a field.
 
-![markers](https://raw.githubusercontent.com/google/blockly-samples/master/blockly-rtc/markers.png)
+![markers](https://raw.githubusercontent.com/RaspberryPiFoundation/blockly-samples/master/blockly-rtc/markers.png)
 
 The image above shows a yellow marker for one user, a blue marker for a second user, and a green marker for a third user.

--- a/examples/developer-tools/package.json
+++ b/examples/developer-tools/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/google/blockly-samples.git"
+    "url": "git+https://github.com/RaspberryPiFoundation/blockly-samples.git"
   },
   "keywords": [
     "blockly"
@@ -23,9 +23,9 @@
   "author": "Blockly Team",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
-  "homepage": "https://github.com/google/blockly-samples#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples#readme",
   "devDependencies": {
     "@webpack-cli/generators": "^3.0.7",
     "css-loader": "^6.8.1",

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -19,7 +19,7 @@ To test locally with a beta version of Blockly, go to the root of blockly-sample
 
 ### One-click
 
-Run the [Update GitHub Pages Action](https://github.com/google/blockly-samples/actions/workflows/update_gh_pages.yml) from either the `google/blockly-samples` repo or your fork to deploy to that location automatically. Click the "Run workflow" button to start it. After this workflow finishes, GitHub's built-in "build and deploy" action will automatically start. When that finishes, the updated site will be live.
+Run the [Update GitHub Pages Action](https://github.com/RaspberryPiFoundation/blockly-samples/actions/workflows/update_gh_pages.yml) from either the `RaspberryPiFoundation/blockly-samples` repo or your fork to deploy to that location automatically. Click the "Run workflow" button to start it. After this workflow finishes, GitHub's built-in "build and deploy" action will automatically start. When that finishes, the updated site will be live.
 
 Note: Updating GitHub Pages is done automatically when publishing plugins through the Publish action.
 

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -21,13 +21,13 @@
     "blockly-plugin",
     "block-dynamic-connection"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/block-dynamic-connection#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/block-dynamic-connection#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/block-dynamic-connection"
   },
   "license": "Apache-2.0",

--- a/plugins/block-plus-minus/README.md
+++ b/plugins/block-plus-minus/README.md
@@ -6,7 +6,7 @@ based UI.
 Currently this only affects the built-in blocks that use mutators (controls_if, text_join, list_create_with,
 procedures_defnoreturn, and procedures_defreturn).
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/If.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/If.png)
 
 But the ability to easily add this to your own mutators may be added
 in the future.
@@ -59,7 +59,7 @@ add specific mutations of blocks:
 <block type="controls_if"></block>
 ```
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/If.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/If.png)
 
 ```xml
 <block type="controls_if">
@@ -67,7 +67,7 @@ add specific mutations of blocks:
 </block>
 ```
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/IfElseIf.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/IfElseIf.png)
 
 ```xml
 <block type="controls_if">
@@ -75,7 +75,7 @@ add specific mutations of blocks:
 </block>
 ```
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/IfElseIfElse.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/IfElseIfElse.png)
 
 #### Text Join
 
@@ -83,7 +83,7 @@ add specific mutations of blocks:
 <block type="text_join"></block>
 ```
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/TextJoin.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/TextJoin.png)
 
 ```xml
 <block type="text_join">
@@ -91,7 +91,7 @@ add specific mutations of blocks:
 </block>
 ```
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/TextJoinNone.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/TextJoinNone.png)
 
 #### List Create
 
@@ -99,7 +99,7 @@ add specific mutations of blocks:
 <block type="lists_create_with"></block>
 ```
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/ListCreateWith.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/ListCreateWith.png)
 
 ```xml
 <block type="lists_create_with">
@@ -107,7 +107,7 @@ add specific mutations of blocks:
 </block>
 ```
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/ListCreateWithNone.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/block-plus-minus/readme-media/ListCreateWithNone.png)
 
 ## License
 

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -20,13 +20,13 @@
     "block",
     "mutator"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/block-plus-minus#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/block-plus-minus#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/block-plus-minus"
   },
   "license": "Apache-2.0",

--- a/plugins/block-plus-minus/src/list_create.js
+++ b/plugins/block-plus-minus/src/list_create.js
@@ -13,7 +13,7 @@ import {createPlusField} from './field_plus';
 import {createMinusField} from './field_minus';
 
 // Delete original block because there's no way to unregister it:
-// https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
+// https://github.com/RaspberryPiFoundation/blockly-samples/issues/768#issuecomment-885663394
 delete Blockly.Blocks['lists_create_with'];
 
 Blockly.defineBlocksWithJsonArray([

--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -15,7 +15,7 @@ import {createPlusField} from './field_plus';
 Blockly.Msg['PROCEDURE_VARIABLE'] = 'variable:';
 
 // Delete original blocks because there's no way to unregister them:
-// https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
+// https://github.com/RaspberryPiFoundation/blockly-samples/issues/768#issuecomment-885663394
 delete Blockly.Blocks['procedures_defnoreturn'];
 delete Blockly.Blocks['procedures_defreturn'];
 

--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -22,13 +22,13 @@
     "blockly-block",
     "shareable-procedures"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/block-shareable-procedures#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/block-shareable-procedures#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/block-shareable-procedures"
   },
   "license": "Apache-2.0",

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -1306,7 +1306,7 @@ suite('Procedures', function () {
         'with arguments that call another procedure does not cause a crash',
       function () {
         // This test exercises the scenario reported in
-        // https://github.com/google/blockly-samples/issues/2557
+        // https://github.com/RaspberryPiFoundation/blockly-samples/issues/2557
         Blockly.serialization.workspaces.load(
           {
             blocks: {

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -20,13 +20,13 @@
     "blockly-block",
     "test"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/block-test#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/block-test#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/block-test"
   },
   "license": "Apache 2.0",

--- a/plugins/content-highlight/README.md
+++ b/plugins/content-highlight/README.md
@@ -3,7 +3,7 @@
 A [Blockly](https://www.npmjs.com/package/blockly) plugin that highlights the
 content on the workspace.
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/content-highlight/readme-media/content-highlight.gif)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/content-highlight/readme-media/content-highlight.gif)
 
 ## Installation
 

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -24,13 +24,13 @@
     "highlight",
     "workspace"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/content-highlight#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/content-highlight#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/content-highlight"
   },
   "license": "Apache-2.0",

--- a/plugins/continuous-toolbox/README.md
+++ b/plugins/continuous-toolbox/README.md
@@ -2,7 +2,7 @@
 
 A [Blockly](https://www.npmjs.com/package/blockly) plugin that creates a continuous-scrolling style toolbox/flyout that is always open. All of the blocks from all categories are in the flyout together, and the user can either click a category name in the toolbox or scroll to the category they're looking for. This flyout only works as a vertical flyout and it works in both left-to-right and right-to-left modes. Parts of the toolbox style have been changed already, but you can customize the style further by following the [toolbox documentation](https://developers.google.com/blockly/guides/configure/web/toolbox).
 
-![Screenshot of continuous toolbox showing multiple categories of blocks in the flyout at once](https://github.com/google/blockly-samples/blob/master/plugins/continuous-toolbox/screenshot.png?raw=true)
+![Screenshot of continuous toolbox showing multiple categories of blocks in the flyout at once](https://github.com/RaspberryPiFoundation/blockly-samples/blob/master/plugins/continuous-toolbox/screenshot.png?raw=true)
 The continuous toolbox is shown here with the 'Zelos' theme, and the style can be further customized.
 
 ## Installation

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -20,13 +20,13 @@
     "blockly-plugin",
     "continuous-toolbox"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/continuous-toolbox#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/continuous-toolbox#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/continuous-toolbox"
   },
   "license": "Apache-2.0",

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -20,13 +20,13 @@
     "blockly",
     "blockly-plugin"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/cross-tab-copy-paste#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/cross-tab-copy-paste#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/cross-tab-copy-paste"
   },
   "license": "Apache-2.0",

--- a/plugins/dev-create/bin/plugin.js
+++ b/plugins/dev-create/bin/plugin.js
@@ -37,7 +37,8 @@ exports.createPlugin = function (pluginName, options) {
 
   const isGit = !!gitURL;
   const isFirstParty =
-    options.firstParty || gitURL == 'https://github.com/google/blockly-samples';
+    options.firstParty ||
+    gitURL == 'https://github.com/RaspberryPiFoundation/blockly-samples';
 
   /**
    * Gets the name of the plugin prefixed with the type.

--- a/plugins/dev-create/package.json
+++ b/plugins/dev-create/package.json
@@ -20,13 +20,13 @@
   "scripts": {
     "prepack": "cp -r ../../examples/sample-app ./templates && cp -r ../../examples/sample-app-ts ./templates"
   },
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/dev-create#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/dev-create#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/dev-create"
   },
   "license": "Apache-2.0",

--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -14,13 +14,13 @@
     "dev",
     "scripts"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/dev-scripts#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/dev-scripts#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/dev-scripts"
   },
   "license": "Apache-2.0",

--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -94,7 +94,7 @@ const toolbox = generateFieldTestBlocks('field_template', [
 ### Test Helpers
 
 This package is also used in mocha tests, and exports a suite of useful test helpers.
-You can find the full list of helpers [here](https://github.com/google/blockly-samples/blob/master/plugins/dev-tools/src/test_helpers.mocha.js).
+You can find the full list of helpers [here](https://github.com/RaspberryPiFoundation/blockly-samples/blob/master/plugins/dev-tools/src/test_helpers.mocha.js).
 
 ### Debug Renderer
 
@@ -114,26 +114,26 @@ The debug renderer can show you several different things.
     <th>Description</th>
   </tr>
     <td><a href="https://developers.google.com/blocklyguides/create-custom-blocks/appearance/renderers/concepts/rows">Rows</a></td>
-    <td><img src="https://github.com/google/blockly-samples/raw/master/plugins/dev-tools/readme-media/row.png"/></td>
+    <td><img src="https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/dev-tools/readme-media/row.png"/></td>
     <td>The bounds of the individual rows in a block.</td>
   <tr>
     <td><a href="https://developers.google.com/blocklyguides/create-custom-blocks/appearance/renderers/concepts/rows#row_spacer">Row spacers</a></td>
-    <td><img src="https://github.com/google/blockly-samples/raw/master/plugins/dev-tools/readme-media/row-spacer.png"/></td>
+    <td><img src="https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/dev-tools/readme-media/row-spacer.png"/></td>
     <td>The bounds of the row spacers in a block.</td>
   </tr>
   <tr>
     <td><a href="https://developers.google.com/blocklyguides/create-custom-blocks/appearance/renderers/concepts/elements">Elements</a></td>
-    <td><img src="https://github.com/google/blockly-samples/raw/master/plugins/dev-tools/readme-media/element.png"/></td>
+    <td><img src="https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/dev-tools/readme-media/element.png"/></td>
     <td>The bounds of the elements in a block.</td>
   </tr>
   <tr>
     <td><a href="https://developers.google.com/blocklyguides/create-custom-blocks/appearance/renderers/concepts/elements#element_spacer">Element spacers</a></td>
-    <td><img src="https://github.com/google/blockly-samples/raw/master/plugins/dev-tools/readme-media/element-spacer.png"/></td>
+    <td><img src="https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/dev-tools/readme-media/element-spacer.png"/></td>
     <td>The bounds of the element spacers in a block.</td>
   </tr>
   <tr>
     <td>Connections</td>
-    <td><img src="https://github.com/google/blockly-samples/raw/master/plugins/dev-tools/readme-media/connection.png"/></td>
+    <td><img src="https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/dev-tools/readme-media/connection.png"/></td>
     <td>
       The locations of the connection points, with large circles for next and
       input connections (parent connections) and small circles for output and
@@ -142,14 +142,14 @@ The debug renderer can show you several different things.
   </tr>
   <tr>
     <td>Block bounds</td>
-    <td><img src="https://github.com/google/blockly-samples/raw/master/plugins/dev-tools/readme-media/block-bounds.png"/></td>
+    <td><img src="https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/dev-tools/readme-media/block-bounds.png"/></td>
     <td>
       The bounds of the block, not including any child blocks.
     </td>
   </tr>
   <tr>
     <td>Connectioned block bounds</td>
-    <td><img src="https://github.com/google/blockly-samples/raw/master/plugins/dev-tools/readme-media/block-bounds-with-children.png"/></td>
+    <td><img src="https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/dev-tools/readme-media/block-bounds-with-children.png"/></td>
     <td>
       The bounds of the block, including child blocks.
     </td>

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -19,13 +19,13 @@
     "dev",
     "tools"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/dev-tools#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/dev-tools#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/dev-tools"
   },
   "license": "Apache-2.0",

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -19,13 +19,13 @@
     "blockly-plugin",
     "disable-top-blocks"
   ],
-  "homepage": "git@github.com:google/blockly-samples/tree/master/plugins/disable-top-blocks#readme",
+  "homepage": "git@github.com:RaspberryPiFoundation/blockly-samples/tree/master/plugins/disable-top-blocks#readme",
   "bugs": {
-    "url": "git@github.com:google/blockly-samples/issues"
+    "url": "git@github.com:RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:google/blockly-samples.git",
+    "url": "git@github.com:RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/disable-top-blocks"
   },
   "license": "Apache-2.0",

--- a/plugins/eslint-config/README.md
+++ b/plugins/eslint-config/README.md
@@ -1,6 +1,6 @@
 # @blockly/eslint-config [![Built on Blockly](https://tinyurl.com/built-on-blockly)](https://github.com/google/blockly)
 
-> ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) used by [Blockly plugins](https://github.com/google/blockly-samples/tree/master/plugins)
+> ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) used by [Blockly plugins](https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins)
 
 ## Installation
 

--- a/plugins/eslint-config/package.json
+++ b/plugins/eslint-config/package.json
@@ -13,13 +13,13 @@
     "eslintplugin",
     "dev"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/eslint-config#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/eslint-config#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/eslint-config"
   },
   "license": "Apache-2.0",

--- a/plugins/field-angle/package.json
+++ b/plugins/field-angle/package.json
@@ -21,13 +21,13 @@
     "field",
     "angle"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-angle#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-angle#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-angle"
   },
   "license": "Apache-2.0",

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -21,13 +21,13 @@
     "blockly-field",
     "bitmap"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/field-bitmap#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/field-bitmap#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "field-bitmap"
   },
   "license": "Apache-2.0",

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -22,13 +22,13 @@
     "hsv",
     "slider"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-colour-hsv-sliders#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-colour-hsv-sliders#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-colour-hsv-sliders"
   },
   "license": "Apache-2.0",

--- a/plugins/field-colour/README.md
+++ b/plugins/field-colour/README.md
@@ -35,15 +35,15 @@ with the format `#rgb` if possible.
 
 #### Colour field
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/field-colour/readme-media/on_block.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/field-colour/readme-media/on_block.png)
 
 #### Colour field with editor open
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/field-colour/readme-media/with_editor.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/field-colour/readme-media/with_editor.png)
 
 #### Colour field on collapsed block
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/field-colour/readme-media/collapsed.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/field-colour/readme-media/collapsed.png)
 
 ### Creation
 
@@ -207,7 +207,7 @@ Blockly.Blocks['example_colour'] = {
 };
 ```
 
-![Customized colour field editor](https://github.com/google/blockly-samples/raw/master/plugins/field-colour/readme-media/customized.png)
+![Customized colour field editor](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/field-colour/readme-media/customized.png)
 
 #### Creating a colour validator
 
@@ -229,7 +229,7 @@ function(newValue) {
 
 #### Block changing colour based on its colour field
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/field-colour/readme-media/validator.gif)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/field-colour/readme-media/validator.gif)
 
 ### Blocks
 

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -21,13 +21,13 @@
     "field",
     "colour"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-colour#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-colour#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-colour"
   },
   "license": "Apache-2.0",

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -23,13 +23,13 @@
     "date",
     "datepicker"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-date#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-date#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-date"
   },
   "license": "Apache-2.0",

--- a/plugins/field-dependent-dropdown/package.json
+++ b/plugins/field-dependent-dropdown/package.json
@@ -22,13 +22,13 @@
     "hsv",
     "slider"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-dependent-dropdown#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-dependent-dropdown#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-dependent-dropdown"
   },
   "license": "Apache-2.0",

--- a/plugins/field-grid-dropdown/README.md
+++ b/plugins/field-grid-dropdown/README.md
@@ -2,9 +2,9 @@
 
 A [Blockly](https://www.npmjs.com/package/blockly) dropdown field with grid layout.
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/field-grid-dropdown/readme-media/dropdown.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/field-grid-dropdown/readme-media/dropdown.png)
 
-![](https://github.com/google/blockly-samples/raw/master/plugins/field-grid-dropdown/readme-media/dropdown-images.png)
+![](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/field-grid-dropdown/readme-media/dropdown-images.png)
 
 ## Installation
 

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -20,13 +20,13 @@
     "blockly-field",
     "grid-dropdown"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-grid-dropdown#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-grid-dropdown#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-grid-dropdown"
   },
   "license": "Apache 2.0",

--- a/plugins/field-multilineinput/package.json
+++ b/plugins/field-multilineinput/package.json
@@ -21,13 +21,13 @@
     "field",
     "multilineinput"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-multilineinput#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-multilineinput#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-multilineinput"
   },
   "license": "Apache-2.0",

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -20,13 +20,13 @@
     "field",
     "slider"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/field-slider#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/field-slider#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/field-slider"
   },
   "license": "Apache-2.0",

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -19,13 +19,13 @@
     "blockly-plugin",
     "fixed-edges"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/fixed-edges#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/fixed-edges#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "fixed-edges"
   },
   "license": "Apache-2.0",

--- a/plugins/migration/package.json
+++ b/plugins/migration/package.json
@@ -14,13 +14,13 @@
     "migrate",
     "version"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/migration#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/migration#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/migration"
   },
   "license": "Apache-2.0",

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -20,13 +20,13 @@
     "blockly-plugin",
     "modal"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/modal#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/modal#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/modal"
   },
   "license": "Apache 2.0",

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -20,13 +20,13 @@
     "blockly-plugin",
     "scroll-options"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/scroll-options#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/scroll-options#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/scroll-options"
   },
   "license": "Apache-2.0",

--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -20,13 +20,13 @@
     "shadow",
     "block"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/shadow-block-converter#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/shadow-block-converter#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/shadow-block-converter"
   },
   "license": "Apache-2.0",

--- a/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
+++ b/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
@@ -36,7 +36,7 @@ suite('shadowBlockConversionChangeListener', function () {
       '<!DOCTYPE html><div id="blocklyDiv"></div>',
       {pretendToBeVisual: true},
     );
-    // See https://github.com/google/blockly-samples/issues/2528 for context.
+    // See https://github.com/RaspberryPiFoundation/blockly-samples/issues/2528 for context.
     global.SVGElement = window.SVGElement;
 
     this.workspace = Blockly.inject('blocklyDiv');

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -21,13 +21,13 @@
     "strict-connection-checker",
     "connection-checker"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/strict-connection-checker#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/strict-connection-checker#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/strict-connection-checker"
   },
   "license": "Apache 2.0",

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -21,13 +21,13 @@
     "suggested-blocks",
     "@blockly/suggested-blocks"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/suggested-blocks#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/suggested-blocks#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/suggested-blocks"
   },
   "license": "Apache-2.0",

--- a/plugins/theme-dark/README.md
+++ b/plugins/theme-dark/README.md
@@ -2,7 +2,7 @@
 
 A [Blockly](https://www.npmjs.com/package/blockly) dark theme.
 
-![A Blockly workspace using the dark theme.](https://github.com/google/blockly-samples/raw/master/plugins/theme-dark/readme-media/DarkTheme.png)
+![A Blockly workspace using the dark theme.](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/theme-dark/readme-media/DarkTheme.png)
 
 ## Installation
 

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -21,13 +21,13 @@
     "blockly-theme",
     "dark"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/theme-dark#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/theme-dark#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/theme-dark"
   },
   "license": "Apache-2.0",

--- a/plugins/theme-deuteranopia/README.md
+++ b/plugins/theme-deuteranopia/README.md
@@ -4,7 +4,7 @@ A [Blockly](https://www.npmjs.com/package/blockly) theme for people that have
 deuteranopia (the inability to perceive green light). This can also be used for
 people that have protanopia (the inability to perceive red light).
 
-![A Blockly workspace using the deuteranopia theme.](https://github.com/google/blockly-samples/raw/master/plugins/theme-deuteranopia/readme-media/DeuteranopiaTheme.png)
+![A Blockly workspace using the deuteranopia theme.](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/theme-deuteranopia/readme-media/DeuteranopiaTheme.png)
 
 ## Installation
 

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -21,13 +21,13 @@
     "blockly-theme",
     "deuteranopia"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/theme-deuteranopia#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/theme-deuteranopia#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/theme-deuteranopia"
   },
   "license": "Apache-2.0",

--- a/plugins/theme-hackermode/package.json
+++ b/plugins/theme-hackermode/package.json
@@ -22,13 +22,13 @@
     "blockly-theme",
     "theme-hackermode"
   ],
-  "homepage": "git@github.com:google/blockly-samples/tree/master/plugins/theme-hackermode#readme",
+  "homepage": "git@github.com:RaspberryPiFoundation/blockly-samples/tree/master/plugins/theme-hackermode#readme",
   "bugs": {
-    "url": "git@github.com:google/blockly-samples/issues"
+    "url": "git@github.com:RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:google/blockly-samples.git",
+    "url": "git@github.com:RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/theme-hackermode"
   },
   "license": "Apache-2.0",

--- a/plugins/theme-highcontrast/README.md
+++ b/plugins/theme-highcontrast/README.md
@@ -3,7 +3,7 @@
 A [Blockly](https://www.npmjs.com/package/blockly theme that uses darker colors
 for the blocks to create contrast between the block color and the white text.
 
-![A Blockly workspace using the high contrast theme.](https://github.com/google/blockly-samples/raw/master/plugins/theme-highcontrast/readme-media/HighContrastTheme.png)
+![A Blockly workspace using the high contrast theme.](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/theme-highcontrast/readme-media/HighContrastTheme.png)
 
 ## Installation
 

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -21,13 +21,13 @@
     "blockly-theme",
     "highcontrast"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/theme-highcontrast#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/theme-highcontrast#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/theme-highcontrast"
   },
   "license": "Apache-2.0",

--- a/plugins/theme-modern/README.md
+++ b/plugins/theme-modern/README.md
@@ -5,7 +5,7 @@ same block colours as the [Classic theme](https://github.com/google/blockly/blob
 but with darker borders. This theme was designed to be used with the Thrasos or
 Zelos renderer.
 
-![A Blockly workspace using the modern theme.](https://github.com/google/blockly-samples/raw/master/plugins/theme-modern/readme-media/ModernTheme.png)
+![A Blockly workspace using the modern theme.](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/theme-modern/readme-media/ModernTheme.png)
 
 ## Installation
 

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -21,13 +21,13 @@
     "blockly-theme",
     "modern"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/theme-modern#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/theme-modern#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/theme-modern"
   },
   "license": "Apache-2.0",

--- a/plugins/theme-tritanopia/README.md
+++ b/plugins/theme-tritanopia/README.md
@@ -3,7 +3,7 @@
 A [Blockly](https://www.npmjs.com/package/blockly) theme for people that have
 tritanopia (the inability to perceive blue light).
 
-![A Blockly workspace using the tritanopia theme.](https://github.com/google/blockly-samples/raw/master/plugins/theme-tritanopia/readme-media/TritanopiaTheme.png)
+![A Blockly workspace using the tritanopia theme.](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/theme-tritanopia/readme-media/TritanopiaTheme.png)
 
 ## Installation
 

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -21,13 +21,13 @@
     "blockly-theme",
     "tritanopia"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/theme-tritanopia#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/theme-tritanopia#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/theme-tritanopia"
   },
   "license": "Apache-2.0",

--- a/plugins/toolbox-search/package.json
+++ b/plugins/toolbox-search/package.json
@@ -21,13 +21,13 @@
     "toolbox search",
     "block search"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/toolbox-search#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/toolbox-search#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/toolbox-search"
   },
   "license": "Apache-2.0",

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -20,13 +20,13 @@
     "modal",
     "typed variables"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/typed-variable-modal#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/typed-variable-modal#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/typed-variable-modal"
   },
   "license": "Apache-2.0",

--- a/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
+++ b/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
@@ -94,7 +94,7 @@ suite('TypedVariableModal', function () {
     //
     // This test is failing due to the modal and typed-variable-modal
     // plugins each getting separate copies of Blockly due to updates
-    // to dev-tool's webpack.config.js in google/blockly-samples#2228
+    // to dev-tool's webpack.config.js in RaspberryPiFoundation/blockly-samples#2228
     // to support having an exports stanza in Blockly's package.json.
     test.skip('Elements focused', function () {
       this.typedVarModal.init();

--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -28,7 +28,7 @@ The following context menu options are available for the backpack:
 - "Copy to Backpack" on a Block stack in main Workspace
 - "Empty" option when right clicking the Backpack that is disabled if the Backpack is empty
 
-![An animated picture of all the context menu options in use](https://github.com/google/blockly-samples/raw/master/plugins/workspace-backpack/readme-media/context-menu.gif)
+![An animated picture of all the context menu options in use](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/workspace-backpack/readme-media/context-menu.gif)
 
 ## Usage
 
@@ -115,7 +115,7 @@ context menu option from disabling the context menu option if the block is
 already in the Backpack. Setting this flag to `true` to disable the check can be
 beneficial for performance if you expect blocks stacks to be very large.
 
-![An animated picture of the "Copy to Backpack" context menu](https://github.com/google/blockly-samples/raw/master/plugins/workspace-backpack/readme-media/context-menu-precondition.gif)
+![An animated picture of the "Copy to Backpack" context menu](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/workspace-backpack/readme-media/context-menu-precondition.gif)
 
 Note: Currently the empty Backpack context menu is registered globally, while
 the others are registered per workspace.
@@ -219,4 +219,4 @@ This interface requires the draggable to have a method that converts it into
 Apache 2.0
 
 [flyout-info]: https://developers.google.com/blockly/reference/js/blockly.utils_namespace.toolbox_namespace.flyoutiteminfo_typealias.md
-[backpackable]: https://github.com/google/blockly-samples/blob/master/plugins/workspace-backpack/src/backpack.ts
+[backpackable]: https://github.com/RaspberryPiFoundation/blockly-samples/blob/master/plugins/workspace-backpack/src/backpack.ts

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -21,13 +21,13 @@
     "workspace",
     "backpack"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/workspace-backpack#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/workspace-backpack#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/backpack"
   },
   "license": "Apache-2.0",

--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -657,7 +657,7 @@ export class Backpack
     this.contents_ = [];
     this.contents_ = this.filterDuplicates(
       // Support XML serialized content for backwards compatiblity:
-      // https://github.com/google/blockly-samples/issues/1827
+      // https://github.com/RaspberryPiFoundation/blockly-samples/issues/1827
       contents.map((content) =>
         content.startsWith('<block')
           ? this.blockXmlToJsonString(content)

--- a/plugins/workspace-minimap/README.md
+++ b/plugins/workspace-minimap/README.md
@@ -3,7 +3,7 @@
 A [Blockly](https://www.npmjs.com/package/blockly) plugin that adds a minimap to the workspace. A minimap is a miniature version of your blocks that appears on top of your main workspace. This gives you an overview of what your code looks like, and how it is organized.
 There is a focus region within the minimap that highlights the users's current viewport; this is on by default.
 
-![Minimap example](https://github.com/google/blockly-samples/raw/master/plugins/workspace-minimap/readme-media/sample_minimap.png)
+![Minimap example](https://github.com/RaspberryPiFoundation/blockly-samples/raw/master/plugins/workspace-minimap/readme-media/sample_minimap.png)
 
 ## Installation
 

--- a/plugins/workspace-minimap/package.json
+++ b/plugins/workspace-minimap/package.json
@@ -20,13 +20,13 @@
     "blockly-plugin",
     "workspace-minimap"
   ],
-  "homepage": "git@github.com:google/blockly-samples/tree/master/plugins/workspace-minimap#readme",
+  "homepage": "git@github.com:RaspberryPiFoundation/blockly-samples/tree/master/plugins/workspace-minimap#readme",
   "bugs": {
-    "url": "git@github.com:google/blockly-samples/issues"
+    "url": "git@github.com:RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:google/blockly-samples.git",
+    "url": "git@github.com:RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/workspace-minimap"
   },
   "license": "Apache-2.0",

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -20,13 +20,13 @@
     "workspace",
     "search"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/workspace-search#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/workspace-search#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/workspace-search"
   },
   "license": "Apache-2.0",

--- a/plugins/workspace-search/test/workspace_search_test.mocha.js
+++ b/plugins/workspace-search/test/workspace_search_test.mocha.js
@@ -69,7 +69,7 @@ suite('WorkspaceSearch', function () {
     );
     this.workspace = Blockly.inject('blocklyDiv');
     this.workspaceSearch = new WorkspaceSearch(this.workspace);
-    // See https://github.com/google/blockly-samples/issues/2528 for context.
+    // See https://github.com/RaspberryPiFoundation/blockly-samples/issues/2528 for context.
     global.SVGElement = window.SVGElement;
   });
 

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -19,13 +19,13 @@
     "blockly-plugin",
     "zoom-to-fit"
   ],
-  "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/zoom-to-fit#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly-samples/tree/master/plugins/zoom-to-fit#readme",
   "bugs": {
-    "url": "https://github.com/google/blockly-samples/issues"
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/blockly-samples.git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly-samples.git",
     "directory": "plugins/zoom-to-fit"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Works on publishing blockly-samples

### Proposed Changes

- Updates all the URLs in plugin package.json files to point to RPF

### Reason for Changes

Trusted publishing fails because the repository URLs do not match:

```
error: 'Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/google/blockly-samples.git", expected to match "https://github.com/RaspberryPiFoundation/blockly-samples" from provenance'
```

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
