### PR TITLE
fix: Restore `extraState` to `lists_create_with` in the sample toolbox

### DIFF
--- a/plugins/dev-tools/src/toolboxCategories.js
+++ b/plugins/dev-tools/src/toolboxCategories.js
@@ -624,6 +624,9 @@ export default {
         {
           type: 'lists_create_with',
           kind: 'block',
+          extraState: {
+            itemCount: 0,
+          },
         },
         {
           type: 'lists_create_with',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2644

### Proposed Changes
This PR adds some `extraState` back to the `lists_create_with` blocks in the sample toolbox from dev-tools; previously, there were two identical blocks shown, which was a regression from earlier when the same block with a different number of inputs was present.