### PR TITLE
fix: Remove unsafe cast in ContinuousFlyout

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -76,10 +76,10 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
     const toolbox = this.targetWorkspace.getToolbox();
     if (!toolbox || toolbox instanceof ContinuousToolbox) return toolbox;
 
-    console.log(
+    console.warn(
       'Expected a `ContinuousToolbox` instance but did not find one. ' +
-      'Make sure `registerContinuousToolbox()` has been called and the ' +
-      'continuous toolbox has been injected.'
+        'Make sure `registerContinuousToolbox()` has been called and the ' +
+        'continuous toolbox has been injected.',
     );
 
     return null;

--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -72,8 +72,17 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
    *
    * @returns Toolbox that owns this flyout.
    */
-  private getParentToolbox(): ContinuousToolbox {
-    return this.targetWorkspace.getToolbox() as ContinuousToolbox;
+  private getParentToolbox(): ContinuousToolbox | null {
+    const toolbox = this.targetWorkspace.getToolbox();
+    if (!toolbox || toolbox instanceof ContinuousToolbox) return toolbox;
+
+    console.log(
+      'Expected a `ContinuousToolbox` instance but did not find one. ' +
+      'Make sure `registerContinuousToolbox()` has been called and the ' +
+      'continuous toolbox has been injected.'
+    );
+
+    return null;
   }
 
   /**
@@ -110,7 +119,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
       // Note that `FlyoutButton` represents both buttons and labels.
       element instanceof Blockly.FlyoutButton &&
       element.isLabel() &&
-      this.getParentToolbox().getCategoryByName(element.getButtonText())
+      this.getParentToolbox()?.getCategoryByName(element.getButtonText())
     );
   }
 
@@ -146,7 +155,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
       ...this.scrollPositions.entries(),
     ].reverse()) {
       if (scaledPosition >= position) {
-        this.getParentToolbox().selectCategoryByName(name);
+        this.getParentToolbox()?.selectCategoryByName(name);
         return;
       }
     }
@@ -271,7 +280,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
     super.show(flyoutDef);
     this.recordScrollPositions();
     this.getWorkspace().resizeContents();
-    if (!this.getParentToolbox().getSelectedItem()) {
+    if (!this.getParentToolbox()?.getSelectedItem()) {
       this.selectCategoryByScrollPosition(0);
     }
     this.getRecyclableInflater().emptyRecycledBlocks();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/8884

### Proposed Changes
This PR removes an unsafe cast that was assuming the parent toolbox is always non-null. I wasn't able to reproduce the behavior described in [#8884](https://github.com/RaspberryPiFoundation/blockly/issues/8884), but the stacktrace indicates that the toolbox was null on one of these lines, so handling that case should resolve it.