### PR TITLE
Fix handling of checkbox values in developer tools

### DIFF
--- a/examples/developer-tools/src/output-generators/fields/checkbox.ts
+++ b/examples/developer-tools/src/output-generators/fields/checkbox.ts
@@ -30,7 +30,7 @@ jsonDefinitionGenerator.forBlock['field_checkbox'] = function (
   const code = {
     type: 'field_checkbox',
     name: block.getFieldValue('FIELDNAME'),
-    checked: block.getFieldValue('CHECKED'),
+    checked: block.getFieldValue('CHECKED') === 'TRUE',
   };
   return JSON.stringify(code);
 };
@@ -40,7 +40,7 @@ javascriptDefinitionGenerator.forBlock['field_checkbox'] = function (
   generator: JavascriptDefinitionGenerator,
 ): string {
   const name = generator.quote_(block.getFieldValue('FIELDNAME'));
-  const checked = generator.quote_(block.getFieldValue('CHECKED'));
+  const checked = block.getFieldValue('CHECKED') === 'TRUE';
   return `.appendField(new Blockly.FieldCheckbox(${checked}), ${name})`;
 };
 

--- a/examples/developer-tools/src/output-generators/fields/image.ts
+++ b/examples/developer-tools/src/output-generators/fields/image.ts
@@ -33,7 +33,7 @@ jsonDefinitionGenerator.forBlock['field_image'] = function (
     width: block.getFieldValue('WIDTH'),
     height: block.getFieldValue('HEIGHT'),
     alt: block.getFieldValue('ALT'),
-    flipRtl: block.getFieldValue('FLIP_RTL'),
+    flipRtl: block.getFieldValue('FLIP_RTL') === 'TRUE',
   };
   return JSON.stringify(code);
 };
@@ -46,7 +46,7 @@ javascriptDefinitionGenerator.forBlock['field_image'] = function (
   const width = block.getFieldValue('WIDTH');
   const height = block.getFieldValue('HEIGHT');
   const alt = generator.quote_(block.getFieldValue('ALT'));
-  const flipRtl = generator.quote_(block.getFieldValue('FLIP_RTL'));
+  const flipRtl = block.getFieldValue('FLIP_RTL') === 'TRUE';
 
   const code = `.appendField(new Blockly.FieldImage(${src}, ${width}, ${height}, { alt: ${alt}, flipRtl: ${flipRtl}}))`;
   return code;


### PR DESCRIPTION
The Checkbox field's values are not booleans but strings `'TRUE'` or `'FALSE`'.
The string `'FALSE'` is truthy in Javascript, so Image field definitions copied from this block creator would always inadvertently have `flipRtl` set to `true`.
This patch adds conversion from the checkbox string to its boolean value to ensure intended behavior.
The Checkbox field accepts both `'TRUE'`/`'FALSE'` strings and booleans so it works in practice, but the Typescript API specifies that the JSON config value should be boolean, so I added boolean conversion there too.