### PR TITLE
fix: Fix creation of variables in the main workspace when opening flyout

### DIFF
--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -74,9 +74,12 @@ export class ObservableParameterModel
     name: string,
     varId?: string,
   ): Blockly.IVariableModel<Blockly.IVariableState> {
-    this.variable =
-      this.workspace.getVariable(name) ??
-      this.workspace.createVariable(name, '', varId);
+    this.variable = Blockly.Variables.getOrCreateVariablePackage(
+      this.workspace,
+      varId || null,
+      name,
+      '',
+    );
     return this.variable;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2685 


### Proposed Changes

Replaced `createBackingVariable` manual get/set calls for variables with Blockly's helper function `getOrCreateVariablePackage` . It handles resolution of variable map correctly (using potentialVariableMap when in flyouts)

### Reason for Changes

Blockly flyouts have `VariableMap` pointing to target workspace's `VariableMap`. Flyouts store their own `VariableMap` inside potentialVariableMap. Method `createBackingVariable` is making `createVariable` calls which creates variables directly on the main workspace

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

N/A
