### PR TITLE
fix: Fix positioning of dropdown on full-block color fields

### DIFF
--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -184,10 +184,11 @@ export class FieldColour extends FieldGridDropdown {
       constants.FIELD_COLOUR_DEFAULT_WIDTH,
       constants.FIELD_COLOUR_DEFAULT_HEIGHT,
     );
-    this.createBorderRect_();
-    this.getBorderRect().style['fillOpacity'] = '1';
     if (this.isFullBlockField()) {
       this.clickTarget_ = (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot();
+    } else {
+      this.createBorderRect_();
+      this.getBorderRect().style['fillOpacity'] = '1';
     }
 
     if (this.fieldGroup_) {
@@ -254,15 +255,14 @@ export class FieldColour extends FieldGridDropdown {
     if (!this.fieldGroup_) return;
 
     const borderRect = this.borderRect_;
-    if (!borderRect) {
-      throw new Error('The border rect has not been initialized');
-    }
 
     if (!this.isFullBlockField()) {
+      if (!borderRect) {
+        throw new Error('The border rect has not been initialized');
+      }
       borderRect.style.display = 'block';
       borderRect.style.fill = this.getValue() as string;
     } else {
-      borderRect.style.display = 'none';
       // In general, do *not* let fields control the color of blocks. Having the
       // field control the color is unexpected, and could have performance
       // impacts.
@@ -502,7 +502,8 @@ export interface FieldColourConfig extends FieldGridDropdownConfig {
 /**
  * fromJson config options for the colour field.
  */
-export interface FieldColourFromJsonConfig extends FieldGridDropdownFromJsonConfig {
+export interface FieldColourFromJsonConfig
+  extends FieldGridDropdownFromJsonConfig {
   colour?: string;
 }
 

--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -502,8 +502,7 @@ export interface FieldColourConfig extends FieldGridDropdownConfig {
 /**
  * fromJson config options for the colour field.
  */
-export interface FieldColourFromJsonConfig
-  extends FieldGridDropdownFromJsonConfig {
+export interface FieldColourFromJsonConfig extends FieldGridDropdownFromJsonConfig {
   colour?: string;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2742

### Proposed Changes
This PR fixes a bug that caused the dropdown to be mispositioned for full-block color fields. Previously, these fields were always creating a border rect and setting it hidden if they were full-block; the superclass however used the presence or absence thereof as a proxy for being full-block when computing the field's bounding box, causing an incorrect bounding box to be generated for a full-block color field, which in turn caused the dropdowndiv to position itself incorrectly. Now, the color field only creates a border rect if it's not full-block.