### PR TITLE
fix(workspace-search): set search buttons to type='button'

### DIFF
--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -282,6 +282,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
     // Create the button
     const btn = document.createElement('button');
     Blockly.utils.dom.addClass(btn, className);
+    btn.type = 'button';
     btn.setAttribute('aria-label', text);
     return btn;
   }

--- a/plugins/workspace-search/test/workspace_search_test.mocha.js
+++ b/plugins/workspace-search/test/workspace_search_test.mocha.js
@@ -101,6 +101,24 @@ suite('WorkspaceSearch', function () {
     });
   });
 
+  suite('createBtn()', function () {
+    test('Buttons have type button', function () {
+      this.workspaceSearch.init();
+      const nextBtn = document.querySelector(
+        'button.blockly-ws-search-next-btn',
+      );
+      const previousBtn = document.querySelector(
+        'button.blockly-ws-search-previous-btn',
+      );
+      const closeBtn = document.querySelector(
+        'button.blockly-ws-search-close-btn',
+      );
+      assert.equal(nextBtn.type, 'button');
+      assert.equal(previousBtn.type, 'button');
+      assert.equal(closeBtn.type, 'button');
+    });
+  });
+
   suite('dispose()', function () {
     test('DOM is disposed', function () {
       this.workspaceSearch.init();


### PR DESCRIPTION
Fixes #2510.

The workspace-search next/previous/close buttons are created by the private `createBtn` helper without an explicit `type`, so each `<button>` defaults to `type="submit"`. When a Blockly workspace is embedded in a `<form>`, clicking any of them submits the form — exactly as @admalledd reported, along with the one-line fix.

### Change
- `createBtn` now sets `btn.type = 'button'`. This single helper backs all three buttons (next, previous, close), so one line covers every case.
- Added a `createBtn()` regression test asserting the three buttons expose `type === 'button'`. It fails on current `main` (jsdom reports the default `'submit'`) and passes with the fix.

### Checks (Node 22)
- `npm run build --workspace=@blockly/plugin-workspace-search` — OK
- `npm run test --workspace=@blockly/plugin-workspace-search` — 17 passing
- `npm run lint` and `npm run format:check` — clean

Thanks to @admalledd for the report and the suggested fix.

---
Disclosure: this change was prepared with AI assistance and reviewed by me before submitting. I ran the checks above in a network-isolated container and published a signed, re-runnable record of that run: https://northset-oss.github.io/verification-pilot/. Contributor self-run — not a maintainer verification.
