### PR TITLE
fix(block-dynamic-connection): recache connection pairs after dynamically adding inputs

### DIFF
--- a/plugins/block-dynamic-connection/src/connection_previewer.ts
+++ b/plugins/block-dynamic-connection/src/connection_previewer.ts
@@ -10,10 +10,10 @@ interface ConnectionPreviewerConstructor {
   new (draggedBlock: Blockly.BlockSvg): Blockly.IConnectionPreviewer;
 }
 
-interface DynamicBlock extends Blockly.BlockSvg {
+type DynamicBlock = Blockly.BlockSvg & {
   onPendingConnection(connection: Blockly.RenderedConnection): void;
   finalizeConnections(): void;
-}
+};
 
 /**
  * A type guard that checks if the given block fulfills the DynamicBlock
@@ -45,10 +45,13 @@ export function decoratePreviewer(
 
     private pendingBlocks: Set<DynamicBlock> = new Set();
 
+    private draggedBlock: Blockly.BlockSvg;
+
     constructor(draggedBlock: Blockly.BlockSvg) {
       const BaseConstructor =
         BasePreviewerConstructor ?? Blockly.InsertionMarkerPreviewer;
       this.basePreviewer = new BaseConstructor(draggedBlock);
+      this.draggedBlock = draggedBlock;
     }
 
     previewReplacement(
@@ -87,15 +90,34 @@ export function decoratePreviewer(
 
     /**
      * If the block is a dynamic block, calls onPendingConnection and
-     * stores the block to be finalized later.
+     * stores the block to be finalized later. When new inputs are added,
+     * refreshes the dragged block's connection-pair cache so constrained
+     * / keyboard moves can see the new connections.
      *
      * @param conn The block to trigger onPendingConnection on.
      */
     private previewDynamism(conn: Blockly.RenderedConnection) {
       const block = conn.getSourceBlock();
-      if (blockIsDynamic(block)) {
-        block.onPendingConnection(conn);
-        this.pendingBlocks.add(block);
+      if (!blockIsDynamic(block)) {
+        return;
+      }
+
+      // During onPendingConnection, dynamic blocks only grow (append inputs);
+      // they never remove or replace them. So an input-count change is enough
+      // to detect when the block shape has changed.
+      const inputCountBefore = block.inputList.length;
+      block.onPendingConnection(conn);
+      this.pendingBlocks.add(block);
+
+      if (block.inputList.length === inputCountBefore) {
+        return;
+      }
+
+      const strategy = this.draggedBlock.getDragStrategy() as {
+        cacheAllConnectionPairs?: () => void;
+      };
+      if (typeof strategy.cacheAllConnectionPairs === 'function') {
+        strategy.cacheAllConnectionPairs();
       }
     }
   };

--- a/plugins/block-dynamic-connection/src/connection_previewer.ts
+++ b/plugins/block-dynamic-connection/src/connection_previewer.ts
@@ -113,10 +113,8 @@ export function decoratePreviewer(
         return;
       }
 
-      const strategy = this.draggedBlock.getDragStrategy() as {
-        cacheAllConnectionPairs?: () => void;
-      };
-      if (typeof strategy.cacheAllConnectionPairs === 'function') {
+      const strategy = this.draggedBlock.getDragStrategy();
+      if (strategy instanceof Blockly.dragging.BlockDragStrategy) {
         strategy.cacheAllConnectionPairs();
       }
     }


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly-samples/issues/2708
Depends upon:
- https://github.com/RaspberryPiFoundation/blockly/pull/10149
### Proposed Changes

After `onPendingConnection()`, if the dynamic block has new inputs, re-cache the compatible connection pairs for the currently dragging block. 
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

As stated in the issue:
> When using `block-dynamic-connection` with Blockly v13, and moving blocks via the keyboard, new connections are correctly added to blocks, but because move mode pre-caches the list of available connections at the start of a keyboard-driven move, they are not offered as connection points in constrained move mode.

This fixes this issue.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

No plugin-level tests were added for this change. A headless test would only verify mocked interactions and would not meaningfully exercise constrained movement. Testing the complete behavior with rendered blocks would require substantial browser, rendering, and drag-state setup disproportionate to the small plugin change.

Instead, Blockly core tests cover the important behavioral contract: after `cacheAllConnectionPairs()` is called during a move, newly added connections are included in the cache and can be visited in the expected traversal order.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This depends upon `BlockDragStrategy.cacheAllConnectionPairs` being made public, so this should only be merged after https://github.com/RaspberryPiFoundation/blockly/pull/10149 is merged and, ideally, released.

<!-- Anything else we should know? -->
