### PR TITLE
fix: Wrong code generation for FieldImage

### DIFF
--- a/examples/developer-tools/src/output-generators/fields/image.ts
+++ b/examples/developer-tools/src/output-generators/fields/image.ts
@@ -48,7 +48,12 @@ javascriptDefinitionGenerator.forBlock['field_image'] = function (
   const alt = generator.quote_(block.getFieldValue('ALT'));
   const flipRtl = block.getFieldValue('FLIP_RTL') === 'TRUE';
 
-  const code = `.appendField(new Blockly.FieldImage(${src}, ${width}, ${height}, { alt: ${alt}, flipRtl: ${flipRtl}}))`;
+  const args = [src, width, height, alt];
+  if (flipRtl) {
+    // The onClick handler argument precedes flipRtl in the constructor.
+    args.push('undefined', 'true');
+  }
+  const code = `.appendField(new Blockly.FieldImage(${args.join(', ')}))`;
   return code;
 };
 


### PR DESCRIPTION
## The basics


- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2691

### Other optional implementations

Alternatively, we could pass the `alt` and `fieldRtl` into the `config`, which is now the seventh, but I think this is the clearer approach.

```
new Blockly.FieldImage(src, width, height, undefined, undefined, undefined, {alt: 'star', flipRtl: true})
```
